### PR TITLE
Permalink settings markup edits

### DIFF
--- a/.env
+++ b/.env
@@ -28,7 +28,7 @@ LOCAL_PHP_MEMCACHED=false
 #
 # Supported values are `mysql` and `mariadb`.
 ##
-LOCAL_DB_TYPE=mysql
+LOCAL_DB_TYPE=mariadb
 
 ##
 # The database version to use.
@@ -38,7 +38,7 @@ LOCAL_DB_TYPE=mysql
 # When using `mysql`, see https://hub.docker.com/_/mysql/ for valid versions.
 # When using `mariadb`, see https://hub.docker.com/_/mariadb for valid versions.
 ##
-LOCAL_DB_VERSION=5.7
+LOCAL_DB_VERSION=10
 
 # The debug settings to add to `wp-config.php`.
 LOCAL_WP_DEBUG=true

--- a/.env
+++ b/.env
@@ -28,7 +28,7 @@ LOCAL_PHP_MEMCACHED=false
 #
 # Supported values are `mysql` and `mariadb`.
 ##
-LOCAL_DB_TYPE=mariadb
+LOCAL_DB_TYPE=mysql
 
 ##
 # The database version to use.
@@ -38,7 +38,7 @@ LOCAL_DB_TYPE=mariadb
 # When using `mysql`, see https://hub.docker.com/_/mysql/ for valid versions.
 # When using `mariadb`, see https://hub.docker.com/_/mariadb for valid versions.
 ##
-LOCAL_DB_VERSION=10
+LOCAL_DB_VERSION=5.7
 
 # The debug settings to add to `wp-config.php`.
 LOCAL_WP_DEBUG=true

--- a/.github/workflows/slack-notifications.yml
+++ b/.github/workflows/slack-notifications.yml
@@ -94,7 +94,13 @@ jobs:
               per_page: 1,
               page: 2,
             });
-            return previous_runs.data.workflow_runs[0].conclusion;
+
+            if ( previous_runs.data.total_count > 0 ) {
+              return previous_runs.data.workflow_runs[0].conclusion;
+            } else {
+              // Use failure so all first time runs for a branch or tag are reported to Slack.
+              return 'failure';
+            }
 
       - name: Store previous conclusion as an output
         id: previous-conclusion

--- a/package-lock.json
+++ b/package-lock.json
@@ -7750,7 +7750,7 @@
 		},
 		"browserify-aes": {
 			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
+			"resolved": "http://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
 			"integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
 			"dev": true,
 			"requires": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -5876,10 +5876,13 @@
 			"dev": true
 		},
 		"agent-base": {
-			"version": "5.1.1",
-			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-5.1.1.tgz",
-			"integrity": "sha512-TMeqbNl2fMW0nMjTEPOwe3J/PRFP4vqeoNuQMG0HlMrtm5QxKqdvAkZ1pRBQ/ulIyDD5Yq0nJ7YbdD8ey0TO3g==",
-			"dev": true
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+			"integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+			"dev": true,
+			"requires": {
+				"debug": "4"
+			}
 		},
 		"airbnb-prop-types": {
 			"version": "2.16.0",
@@ -13617,14 +13620,14 @@
 			}
 		},
 		"grunt-contrib-qunit": {
-			"version": "5.1.1",
-			"resolved": "https://registry.npmjs.org/grunt-contrib-qunit/-/grunt-contrib-qunit-5.1.1.tgz",
-			"integrity": "sha512-W1V+55kWF8TARdCDWEwzrbAoielwqrKKppiTwnu3N2kMa73oQIlKNQOnOq32tzruXdTDZX4B5yYustfNp3bdRA==",
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/grunt-contrib-qunit/-/grunt-contrib-qunit-6.0.0.tgz",
+			"integrity": "sha512-FoEkMkrAUhvdwx7inxF1vQ8MoMIqUY8k9QrvQonMcHpJdHr+cfJ5CGTpf+26GPx9ub+SbkgcICOEUaY8LQgb7w==",
 			"dev": true,
 			"requires": {
 				"eventemitter2": "^6.4.2",
 				"p-each-series": "^2.1.0",
-				"puppeteer": "^5.0.0"
+				"puppeteer": "^9.0.0"
 			},
 			"dependencies": {
 				"eventemitter2": {
@@ -14440,12 +14443,12 @@
 			"dev": true
 		},
 		"https-proxy-agent": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-4.0.0.tgz",
-			"integrity": "sha512-zoDhWrkR3of1l9QAL8/scJZyLu8j/gBkcwcaQOZh7Gyh/+uJQzGVETdgT30akuwkpL8HTRfssqI3BZuV18teDg==",
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
+			"integrity": "sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==",
 			"dev": true,
 			"requires": {
-				"agent-base": "5",
+				"agent-base": "6",
 				"debug": "4"
 			}
 		},
@@ -21407,19 +21410,19 @@
 			"dev": true
 		},
 		"puppeteer": {
-			"version": "5.5.0",
-			"resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-5.5.0.tgz",
-			"integrity": "sha512-OM8ZvTXAhfgFA7wBIIGlPQzvyEETzDjeRa4mZRCRHxYL+GNH5WAuYUQdja3rpWZvkX/JKqmuVgbsxDNsDFjMEg==",
+			"version": "9.1.1",
+			"resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-9.1.1.tgz",
+			"integrity": "sha512-W+nOulP2tYd/ZG99WuZC/I5ljjQQ7EUw/jQGcIb9eu8mDlZxNY2SgcJXTLG9h5gRvqA3uJOe4hZXYsd3EqioMw==",
 			"dev": true,
 			"requires": {
 				"debug": "^4.1.0",
-				"devtools-protocol": "0.0.818844",
+				"devtools-protocol": "0.0.869402",
 				"extract-zip": "^2.0.0",
-				"https-proxy-agent": "^4.0.0",
+				"https-proxy-agent": "^5.0.0",
 				"node-fetch": "^2.6.1",
 				"pkg-dir": "^4.2.0",
 				"progress": "^2.0.1",
-				"proxy-from-env": "^1.0.0",
+				"proxy-from-env": "^1.1.0",
 				"rimraf": "^3.0.2",
 				"tar-fs": "^2.0.0",
 				"unbzip2-stream": "^1.3.3",
@@ -21427,9 +21430,9 @@
 			},
 			"dependencies": {
 				"devtools-protocol": {
-					"version": "0.0.818844",
-					"resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.818844.tgz",
-					"integrity": "sha512-AD1hi7iVJ8OD0aMLQU5VK0XH9LDlA1+BcPIgrAxPfaibx2DbWucuyOhc4oyQCbnvDDO68nN6/LcKfqTP343Jjg==",
+					"version": "0.0.869402",
+					"resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.869402.tgz",
+					"integrity": "sha512-VvlVYY+VDJe639yHs5PHISzdWTLL3Aw8rO4cvUtwvoxFd6FHbE4OpHHcde52M6096uYYazAmd4l0o5VuFRO2WA==",
 					"dev": true
 				},
 				"find-up": {

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
 		"grunt-contrib-cssmin": "~4.0.0",
 		"grunt-contrib-imagemin": "~4.0.0",
 		"grunt-contrib-jshint": "3.1.1",
-		"grunt-contrib-qunit": "^5.1.1",
+		"grunt-contrib-qunit": "~6.0.0",
 		"grunt-contrib-uglify": "~5.0.1",
 		"grunt-contrib-watch": "~1.1.0",
 		"grunt-file-append": "0.0.7",

--- a/src/wp-admin/admin-header.php
+++ b/src/wp-admin/admin-header.php
@@ -22,7 +22,7 @@ if ( ! defined( 'WP_ADMIN' ) ) {
  * @global string    $update_title
  * @global int       $total_update_count
  * @global string    $parent_file
- * @global string    $typenow
+ * @global string    $typenow            The post type of the current screen.
  */
 global $title, $hook_suffix, $current_screen, $wp_locale, $pagenow,
 	$update_title, $total_update_count, $parent_file, $typenow;

--- a/src/wp-admin/admin-header.php
+++ b/src/wp-admin/admin-header.php
@@ -18,7 +18,7 @@ if ( ! defined( 'WP_ADMIN' ) ) {
  * @global string    $hook_suffix
  * @global WP_Screen $current_screen     WordPress current screen object.
  * @global WP_Locale $wp_locale          WordPress date and time locale object.
- * @global string    $pagenow
+ * @global string    $pagenow            The filename of the current screen.
  * @global string    $update_title
  * @global int       $total_update_count
  * @global string    $parent_file

--- a/src/wp-admin/admin.php
+++ b/src/wp-admin/admin.php
@@ -116,11 +116,11 @@ $time_format = __( 'g:i a' );
 wp_enqueue_script( 'common' );
 
 /**
- * $pagenow is set in vars.php
- * $wp_importers is sometimes set in wp-admin/includes/import.php
- * The remaining variables are imported as globals elsewhere, declared as globals here
+ * $pagenow is set in vars.php.
+ * $wp_importers is sometimes set in wp-admin/includes/import.php.
+ * The remaining variables are imported as globals elsewhere, declared as globals here.
  *
- * @global string $pagenow
+ * @global string $pagenow      The filename of the current screen.
  * @global array  $wp_importers
  * @global string $hook_suffix
  * @global string $plugin_page
@@ -376,7 +376,7 @@ if ( isset( $plugin_page ) ) {
 	 * The load-* hook fires in a number of contexts. This hook is for core screens.
 	 *
 	 * The dynamic portion of the hook name, `$pagenow`, is a global variable
-	 * referring to the filename of the current page, such as 'admin.php',
+	 * referring to the filename of the current screen, such as 'admin.php',
 	 * 'post-new.php' etc. A complete hook for the latter would be
 	 * 'load-post-new.php'.
 	 *

--- a/src/wp-admin/admin.php
+++ b/src/wp-admin/admin.php
@@ -124,7 +124,7 @@ wp_enqueue_script( 'common' );
  * @global array  $wp_importers
  * @global string $hook_suffix
  * @global string $plugin_page
- * @global string $typenow
+ * @global string $typenow      The post type of the current screen.
  * @global string $taxnow
  */
 global $pagenow, $wp_importers, $hook_suffix, $plugin_page, $typenow, $taxnow;

--- a/src/wp-admin/admin.php
+++ b/src/wp-admin/admin.php
@@ -125,7 +125,7 @@ wp_enqueue_script( 'common' );
  * @global string $hook_suffix
  * @global string $plugin_page
  * @global string $typenow      The post type of the current screen.
- * @global string $taxnow
+ * @global string $taxnow       The taxonomy of the current screen.
  */
 global $pagenow, $wp_importers, $hook_suffix, $plugin_page, $typenow, $taxnow;
 

--- a/src/wp-admin/css/forms.css
+++ b/src/wp-admin/css/forms.css
@@ -1087,8 +1087,8 @@ table.form-table td .updated p {
 	margin-bottom: 8px!important;
 }
 
-.form-table.permalink-structure .structure-selection .description {
-	margin-left: 24px;
+.form-table.permalink-structure .structure-selection .permalink-description {
+	margin: 0 0 12px 24px;
 }
 
 /*------------------------------------------------------------------------------
@@ -1593,12 +1593,12 @@ table.form-table td .updated p {
 	}
 
 	.form-table.permalink-structure td code {
-		margin-left: 32px;
+		margin-left: 8px;
 		display: inline-block;
 	}
 
 	.form-table.permalink-structure td input[type="text"] {
-		margin-left: 32px;
+		margin-left: 8px;
 		margin-top: 4px;
 		width: 96%;
 	}

--- a/src/wp-admin/css/forms.css
+++ b/src/wp-admin/css/forms.css
@@ -1083,10 +1083,6 @@ table.form-table td .updated p {
 	margin-bottom: 8px;
 }
 
-.form-table.permalink-structure .structure-selection label {
-	margin-bottom: 8px!important;
-}
-
 .form-table.permalink-structure .structure-selection .permalink-description {
 	margin: 0 0 12px 24px;
 }

--- a/src/wp-admin/css/forms.css
+++ b/src/wp-admin/css/forms.css
@@ -1069,18 +1069,9 @@ table.form-table td .updated p {
 	vertical-align: middle;
 }
 
-.form-table.permalink-structure .available-structure-tags fieldset {
-	display: flex;
-	flex-wrap: wrap;
-}
-
-.form-table.permalink-structure .available-structure-tags legend {
-	margin-bottom: 8px;
-}
-
-.form-table.permalink-structure .available-structure-tags button {
-	margin-right: 8px;
-	margin-bottom: 8px;
+.form-table.permalink-structure .available-structure-tags li {
+	float: left;
+	margin-right: 5px;
 }
 
 .form-table.permalink-structure .structure-selection .permalink-description {

--- a/src/wp-admin/edit-form-blocks.php
+++ b/src/wp-admin/edit-form-blocks.php
@@ -151,9 +151,9 @@ if ( $user_id ) {
 	if ( $locked ) {
 		$user         = get_userdata( $user_id );
 		$user_details = array(
-			'name' => $user->display_name,
+			'avatar' => get_avatar_url( $user_id, array( 'size' => 128 ) ),
+			'name'   => $user->display_name,
 		);
-		$avatar       = get_avatar_url( $user_id, array( 'size' => 64 ) );
 	}
 
 	$lock_details = array(

--- a/src/wp-admin/includes/bookmark.php
+++ b/src/wp-admin/includes/bookmark.php
@@ -327,7 +327,7 @@ function wp_update_link( $linkdata ) {
  * @since 3.5.0
  * @access private
  *
- * @global string $pagenow
+ * @global string $pagenow The filename of the current screen.
  */
 function wp_link_manager_disabled_message() {
 	global $pagenow;

--- a/src/wp-admin/includes/class-wp-automatic-updater.php
+++ b/src/wp-admin/includes/class-wp-automatic-updater.php
@@ -1236,9 +1236,15 @@ class WP_Automatic_Updater {
 		$body[] = __( 'https://wordpress.org/support/forums/' );
 		$body[] = "\n" . __( 'The WordPress Team' );
 
+		if ( '' !== get_option( 'blogname' ) ) {
+			$site_title = wp_specialchars_decode( get_option( 'blogname' ), ENT_QUOTES );
+		} else {
+			$site_title = parse_url( home_url(), PHP_URL_HOST );
+		}
+
 		$body    = implode( "\n", $body );
 		$to      = get_site_option( 'admin_email' );
-		$subject = sprintf( $subject, wp_specialchars_decode( get_option( 'blogname' ), ENT_QUOTES ) );
+		$subject = sprintf( $subject, $site_title );
 		$headers = '';
 
 		$email = compact( 'to', 'subject', 'body', 'headers' );
@@ -1347,7 +1353,11 @@ class WP_Automatic_Updater {
 			$body[] = '';
 		}
 
-		$site_title = wp_specialchars_decode( get_bloginfo( 'name' ), ENT_QUOTES );
+		if ( '' !== get_bloginfo( 'name' ) ) {
+			$site_title = wp_specialchars_decode( get_bloginfo( 'name' ), ENT_QUOTES );
+		} else {
+			$site_title = parse_url( home_url(), PHP_URL_HOST );
+		}
 
 		if ( $failures ) {
 			$body[] = trim(

--- a/src/wp-admin/includes/class-wp-automatic-updater.php
+++ b/src/wp-admin/includes/class-wp-automatic-updater.php
@@ -23,7 +23,7 @@ class WP_Automatic_Updater {
 	protected $update_results = array();
 
 	/**
-	 * Whether the entire automatic updater is disabled.
+	 * Determines whether the entire automatic updater is disabled.
 	 *
 	 * @since 3.7.0
 	 */
@@ -56,7 +56,7 @@ class WP_Automatic_Updater {
 	}
 
 	/**
-	 * Check for version control checkouts.
+	 * Checks for version control checkouts.
 	 *
 	 * Checks for Subversion, Git, Mercurial, and Bazaar. It recursively looks up the
 	 * filesystem to the top of the drive, erring on the side of detecting a VCS
@@ -295,7 +295,7 @@ class WP_Automatic_Updater {
 	}
 
 	/**
-	 * Update an item, if appropriate.
+	 * Updates an item, if appropriate.
 	 *
 	 * @since 3.7.0
 	 *

--- a/src/wp-admin/includes/class-wp-plugin-install-list-table.php
+++ b/src/wp-admin/includes/class-wp-plugin-install-list-table.php
@@ -514,7 +514,19 @@ class WP_Plugin_Install_List_Table extends WP_List_Table {
 
 			// Remove any HTML from the description.
 			$description = strip_tags( $plugin['short_description'] );
-			$version     = wp_kses( $plugin['version'], $plugins_allowedtags );
+
+			/**
+			 * Filters the plugin card description on the Add Plugins screen.
+			 *
+			 * @since 6.0.0
+			 *
+			 * @param string $description Plugin card description.
+			 * @param array  $plugin      An array of plugin data. See the {@see 'plugin_row_meta'} filter
+			 *                            for the list of possible values.
+			 */
+			$description = apply_filters( 'plugin_install_description', $description, $plugin );
+
+			$version = wp_kses( $plugin['version'], $plugins_allowedtags );
 
 			$name = strip_tags( $title . ' ' . $version );
 
@@ -660,7 +672,8 @@ class WP_Plugin_Install_List_Table extends WP_List_Table {
 			 * @since 2.7.0
 			 *
 			 * @param string[] $action_links An array of plugin action links. Defaults are links to Details and Install Now.
-			 * @param array    $plugin       The plugin currently being listed.
+			 * @param array    $plugin       An array of plugin data. See the {@see 'plugin_row_meta'} filter
+			 *                               for the list of possible values.
 			 */
 			$action_links = apply_filters( 'plugin_install_action_links', $action_links, $plugin );
 

--- a/src/wp-admin/includes/class-wp-screen.php
+++ b/src/wp-admin/includes/class-wp-screen.php
@@ -403,7 +403,7 @@ final class WP_Screen {
 	 *
 	 * @global WP_Screen $current_screen WordPress current screen object.
 	 * @global string    $typenow        The post type of the current screen.
-	 * @global string    $taxnow
+	 * @global string    $taxnow         The taxonomy of the current screen.
 	 */
 	public function set_current_screen() {
 		global $current_screen, $taxnow, $typenow;

--- a/src/wp-admin/includes/class-wp-screen.php
+++ b/src/wp-admin/includes/class-wp-screen.php
@@ -402,14 +402,15 @@ final class WP_Screen {
 	 * @since 3.3.0
 	 *
 	 * @global WP_Screen $current_screen WordPress current screen object.
+	 * @global string    $typenow        The post type of the current screen.
 	 * @global string    $taxnow
-	 * @global string    $typenow
 	 */
 	public function set_current_screen() {
 		global $current_screen, $taxnow, $typenow;
+
 		$current_screen = $this;
-		$taxnow         = $this->taxonomy;
 		$typenow        = $this->post_type;
+		$taxnow         = $this->taxonomy;
 
 		/**
 		 * Fires after the current screen has been set.

--- a/src/wp-admin/includes/file.php
+++ b/src/wp-admin/includes/file.php
@@ -2146,7 +2146,7 @@ function get_filesystem_method( $args = array(), $context = '', $allow_relaxed_f
  * @since 2.5.0
  * @since 4.6.0 The `$context` parameter default changed from `false` to an empty string.
  *
- * @global string $pagenow
+ * @global string $pagenow The filename of the current screen.
  *
  * @param string        $form_post                    The URL to post the form to.
  * @param string        $type                         Optional. Chosen type of filesystem. Default empty.

--- a/src/wp-admin/includes/misc.php
+++ b/src/wp-admin/includes/misc.php
@@ -1276,7 +1276,7 @@ function wp_refresh_heartbeat_nonces( $response ) {
  *
  * @since 3.8.0
  *
- * @global string $pagenow
+ * @global string $pagenow The filename of the current screen.
  *
  * @param array $settings An array of Heartbeat settings.
  * @return array Filtered Heartbeat settings.

--- a/src/wp-admin/includes/misc.php
+++ b/src/wp-admin/includes/misc.php
@@ -1472,12 +1472,18 @@ All at ###SITENAME###
 	$content      = str_replace( '###SITENAME###', wp_specialchars_decode( get_option( 'blogname' ), ENT_QUOTES ), $content );
 	$content      = str_replace( '###SITEURL###', home_url(), $content );
 
+	if ( '' !== get_option( 'blogname' ) ) {
+		$site_title = wp_specialchars_decode( get_option( 'blogname' ), ENT_QUOTES );
+	} else {
+		$site_title = parse_url( home_url(), PHP_URL_HOST );
+	}
+
 	wp_mail(
 		$value,
 		sprintf(
 			/* translators: New admin email address notification email subject. %s: Site title. */
 			__( '[%s] New Admin Email Address' ),
-			wp_specialchars_decode( get_option( 'blogname' ), ENT_QUOTES )
+			$site_title
 		),
 		$content
 	);

--- a/src/wp-admin/includes/misc.php
+++ b/src/wp-admin/includes/misc.php
@@ -1137,6 +1137,7 @@ function wp_check_locked_posts( $response, $data, $screen_id ) {
 
 				if ( $user && current_user_can( 'edit_post', $post_id ) ) {
 					$send = array(
+						'name' => $user->display_name,
 						/* translators: %s: User's display name. */
 						'text' => sprintf( __( '%s is currently editing' ), $user->display_name ),
 					);

--- a/src/wp-admin/includes/ms.php
+++ b/src/wp-admin/includes/ms.php
@@ -692,7 +692,7 @@ function mu_dropdown_languages( $lang_files = array(), $current = '' ) {
  * @since 3.0.0
  *
  * @global int    $wp_db_version WordPress database version.
- * @global string $pagenow
+ * @global string $pagenow       The filename of the current screen.
  *
  * @return void|false Void on success. False if the current user is not a super admin.
  */
@@ -1029,7 +1029,7 @@ jQuery( function($) {
  *
  * @since 4.6.0
  *
- * @global string $pagenow
+ * @global string $pagenow The filename of the current screen.
  *
  * @param array $args {
  *     Optional. Array or string of Query parameters. Default empty array.

--- a/src/wp-admin/includes/plugin.php
+++ b/src/wp-admin/includes/plugin.php
@@ -1858,7 +1858,7 @@ function menu_page_url( $menu_slug, $echo = true ) {
  * @global string $parent_file
  * @global array  $menu
  * @global array  $submenu
- * @global string $pagenow
+ * @global string $pagenow              The filename of the current screen.
  * @global string $typenow
  * @global string $plugin_page
  * @global array  $_wp_real_parent_file
@@ -1949,7 +1949,7 @@ function get_admin_page_parent( $parent = '' ) {
  * @global string $title
  * @global array $menu
  * @global array $submenu
- * @global string $pagenow
+ * @global string $pagenow     The filename of the current screen.
  * @global string $plugin_page
  * @global string $typenow
  *
@@ -2084,7 +2084,7 @@ function get_plugin_page_hookname( $plugin_page, $parent_page ) {
  *
  * @since 1.5.0
  *
- * @global string $pagenow
+ * @global string $pagenow            The filename of the current screen.
  * @global array  $menu
  * @global array  $submenu
  * @global array  $_wp_menu_nopriv
@@ -2467,7 +2467,7 @@ function resume_plugin( $plugin, $redirect = '' ) {
  *
  * @since 5.2.0
  *
- * @global string $pagenow
+ * @global string $pagenow The filename of the current screen.
  */
 function paused_plugins_notice() {
 	if ( 'plugins.php' === $GLOBALS['pagenow'] ) {
@@ -2500,8 +2500,8 @@ function paused_plugins_notice() {
  * @since 5.8.0
  * @access private
  *
- * @global string $pagenow
- * @global string $wp_version
+ * @global string $pagenow    The filename of the current screen.
+ * @global string $wp_version The WordPress version string.
  */
 function deactivated_plugins_notice() {
 	if ( 'plugins.php' === $GLOBALS['pagenow'] ) {

--- a/src/wp-admin/includes/plugin.php
+++ b/src/wp-admin/includes/plugin.php
@@ -1859,7 +1859,7 @@ function menu_page_url( $menu_slug, $echo = true ) {
  * @global array  $menu
  * @global array  $submenu
  * @global string $pagenow              The filename of the current screen.
- * @global string $typenow
+ * @global string $typenow              The post type of the current screen.
  * @global string $plugin_page
  * @global array  $_wp_real_parent_file
  * @global array  $_wp_menu_nopriv
@@ -1947,16 +1947,16 @@ function get_admin_page_parent( $parent = '' ) {
  * @since 1.5.0
  *
  * @global string $title
- * @global array $menu
- * @global array $submenu
+ * @global array  $menu
+ * @global array  $submenu
  * @global string $pagenow     The filename of the current screen.
+ * @global string $typenow     The post type of the current screen.
  * @global string $plugin_page
- * @global string $typenow
  *
  * @return string The title of the current admin page.
  */
 function get_admin_page_title() {
-	global $title, $menu, $submenu, $pagenow, $plugin_page, $typenow;
+	global $title, $menu, $submenu, $pagenow, $typenow, $plugin_page;
 
 	if ( ! empty( $title ) ) {
 		return $title;

--- a/src/wp-admin/includes/post.php
+++ b/src/wp-admin/includes/post.php
@@ -1069,7 +1069,7 @@ function update_meta( $meta_id, $meta_key, $meta_value ) {
 //
 
 /**
- * Replace hrefs of attachment anchors with up-to-date permalinks.
+ * Replaces hrefs of attachment anchors with up-to-date permalinks.
  *
  * @since 2.3.0
  * @access private
@@ -1361,6 +1361,7 @@ function postbox_classes( $box_id, $screen_id ) {
 	 * @param string[] $classes An array of postbox classes.
 	 */
 	$classes = apply_filters( "postbox_classes_{$screen_id}_{$box_id}", $classes );
+
 	return implode( ' ', $classes );
 }
 
@@ -2336,12 +2337,12 @@ function the_block_editor_meta_boxes() {
 		}
 	}
 
-	/**
+	/*
 	 * Sadly we probably cannot add this data directly into editor settings.
 	 *
-	 * Some meta boxes need admin_head to fire for meta box registry.
-	 * admin_head fires after admin_enqueue_scripts, which is where we create our
-	 * editor instance.
+	 * Some meta boxes need `admin_head` to fire for meta box registry.
+	 * `admin_head` fires after `admin_enqueue_scripts`, which is where we create
+	 * our editor instance.
 	 */
 	$script = 'window._wpLoadBlockEditor.then( function() {
 		wp.data.dispatch( \'core/edit-post\' ).setAvailableMetaBoxesPerLocation( ' . wp_json_encode( $meta_boxes_per_location ) . ' );
@@ -2349,19 +2350,21 @@ function the_block_editor_meta_boxes() {
 
 	wp_add_inline_script( 'wp-edit-post', $script );
 
-	/**
-	 * When `wp-edit-post` is output in the `<head>`, the inline script needs to be manually printed. Otherwise,
-	 * meta boxes will not display because inline scripts for `wp-edit-post` will not be printed again after this point.
+	/*
+	 * When `wp-edit-post` is output in the `<head>`, the inline script needs to be manually printed.
+	 * Otherwise, meta boxes will not display because inline scripts for `wp-edit-post`
+	 * will not be printed again after this point.
 	 */
 	if ( wp_script_is( 'wp-edit-post', 'done' ) ) {
 		printf( "<script type='text/javascript'>\n%s\n</script>\n", trim( $script ) );
 	}
 
-	/**
-	 * If the 'postcustom' meta box is enabled, then we need to perform some
-	 * extra initialization on it.
+	/*
+	 * If the 'postcustom' meta box is enabled, then we need to perform
+	 * some extra initialization on it.
 	 */
 	$enable_custom_fields = (bool) get_user_meta( get_current_user_id(), 'enable_custom_fields', true );
+
 	if ( $enable_custom_fields ) {
 		$script = "( function( $ ) {
 			if ( $('#postcustom').length ) {
@@ -2405,8 +2408,9 @@ function the_block_editor_meta_box_post_form_hidden_fields( $post ) {
 	wp_nonce_field( $nonce_action );
 
 	/*
-	 * Some meta boxes hook into these actions to add hidden input fields in the classic post form. For backwards
-	 * compatibility, we can capture the output from these actions, and extract the hidden input fields.
+	 * Some meta boxes hook into these actions to add hidden input fields in the classic post form.
+	 * For backward compatibility, we can capture the output from these actions,
+	 * and extract the hidden input fields.
 	 */
 	ob_start();
 	/** This filter is documented in wp-admin/edit-form-advanced.php */

--- a/src/wp-admin/includes/post.php
+++ b/src/wp-admin/includes/post.php
@@ -1506,7 +1506,7 @@ function get_sample_permalink_html( $id, $new_title = null, $new_slug = null ) {
 		if ( ! get_option( 'permalink_structure' ) && current_user_can( 'manage_options' )
 			&& ! ( 'page' === get_option( 'show_on_front' ) && get_option( 'page_on_front' ) == $id )
 		) {
-			$return .= '<span id="change-permalinks"><a href="options-permalink.php" class="button button-small" target="_blank">' . __( 'Change Permalinks' ) . "</a></span>\n";
+			$return .= '<span id="change-permalinks"><a href="options-permalink.php" class="button button-small">' . __( 'Change Permalink Structure' ) . "</a></span>\n";
 		}
 	} else {
 		if ( mb_strlen( $post_name ) > 34 ) {

--- a/src/wp-admin/includes/theme.php
+++ b/src/wp-admin/includes/theme.php
@@ -1185,7 +1185,7 @@ function resume_theme( $theme, $redirect = '' ) {
  *
  * @since 5.2.0
  *
- * @global string $pagenow
+ * @global string $pagenow The filename of the current screen.
  */
 function paused_themes_notice() {
 	if ( 'themes.php' === $GLOBALS['pagenow'] ) {

--- a/src/wp-admin/includes/update-core.php
+++ b/src/wp-admin/includes/update-core.php
@@ -1554,7 +1554,7 @@ function _copy_dir( $from, $to, $skip_list = array() ) {
  * @since 3.3.0
  *
  * @global string $wp_version The WordPress version string.
- * @global string $pagenow
+ * @global string $pagenow    The filename of the current screen.
  * @global string $action
  *
  * @param string $new_version

--- a/src/wp-admin/includes/update.php
+++ b/src/wp-admin/includes/update.php
@@ -277,15 +277,15 @@ function core_update_footer( $msg = '' ) {
 /**
  * @since 2.3.0
  *
- * @global string $pagenow
+ * @global string $pagenow The filename of the current screen.
  * @return void|false
  */
 function update_nag() {
+	global $pagenow;
+
 	if ( is_multisite() && ! current_user_can( 'update_core' ) ) {
 		return false;
 	}
-
-	global $pagenow;
 
 	if ( 'update-core.php' === $pagenow ) {
 		return;

--- a/src/wp-admin/includes/user.php
+++ b/src/wp-admin/includes/user.php
@@ -510,10 +510,11 @@ function default_password_nag_edit_user( $user_ID, $old_data ) {
 /**
  * @since 2.8.0
  *
- * @global string $pagenow
+ * @global string $pagenow The filename of the current screen.
  */
 function default_password_nag() {
 	global $pagenow;
+
 	// Short-circuit it.
 	if ( 'profile.php' === $pagenow || ! get_user_option( 'default_password_nag' ) ) {
 		return;

--- a/src/wp-admin/includes/user.php
+++ b/src/wp-admin/includes/user.php
@@ -578,6 +578,12 @@ function admin_created_user_email( $text ) {
 	$roles = get_editable_roles();
 	$role  = $roles[ $_REQUEST['role'] ];
 
+	if ( '' !== get_bloginfo( 'name' ) ) {
+		$site_title = wp_specialchars_decode( get_bloginfo( 'name' ), ENT_QUOTES );
+	} else {
+		$site_title = parse_url( home_url(), PHP_URL_HOST );
+	}
+
 	return sprintf(
 		/* translators: 1: Site title, 2: Site URL, 3: User role. */
 		__(
@@ -590,7 +596,7 @@ this email. This invitation will expire in a few days.
 Please click the following link to activate your user account:
 %%s'
 		),
-		wp_specialchars_decode( get_bloginfo( 'name' ), ENT_QUOTES ),
+		$site_title,
 		home_url(),
 		wp_specialchars_decode( translate_user_role( $role['name'] ) )
 	);

--- a/src/wp-admin/menu-header.php
+++ b/src/wp-admin/menu-header.php
@@ -59,7 +59,7 @@ get_admin_page_parent();
  * @global string $parent_file
  * @global string $submenu_file
  * @global string $plugin_page
- * @global string $typenow
+ * @global string $typenow      The post type of the current screen.
  *
  * @param array $menu
  * @param array $submenu

--- a/src/wp-admin/options-permalink.php
+++ b/src/wp-admin/options-permalink.php
@@ -243,7 +243,7 @@ $structures = array(
 			<th scope="row"><?php _e( 'Select permalink structure' ); ?></th>
 			<td>
 				<fieldset class="structure-selection">
-					<legend class="screen-reader-text"><span><?php _e( 'Select permalink structure' ); ?></span></legend>
+					<legend class="screen-reader-text"><?php _e( 'Select permalink structure' ); ?></legend>
 					<label for="permalink-input-plain">
 						<input id="permalink-input-plain" name="selection" aria-describedby="permalink-plain" type="radio" value="" <?php checked( '', $permalink_structure ); ?> /> <?php _e( 'Plain' ); ?>
 						<p class="description"><code id="permalink-plain"><?php echo get_option( 'home' ); ?>/?p=123</code></p>

--- a/src/wp-admin/options-permalink.php
+++ b/src/wp-admin/options-permalink.php
@@ -266,7 +266,7 @@ $structures = array(
 					</div>
 					<div>
 						<input id="custom_selection" name="selection" type="radio" value="custom" <?php checked( ! in_array( $permalink_structure, $structures, true ) ); ?> /> <label for="custom_selection"><?php _e( 'Custom Structure' ); ?></label>
-						<p class="permalink-description"><label for="permalink_structure" class="screen-reader-text"><?php _e( 'Custom Permalink Structure Tags' ); ?></label><code id="permalink-custom"><?php echo get_option( 'home' ) . $blog_prefix; ?></code><input name="permalink_structure" id="permalink_structure" type="text" value="<?php echo esc_attr( $permalink_structure ); ?>" aria-describedby="permalink-custom" class="regular-text code" /></p>
+						<p class="permalink-description"><label for="permalink_structure" class="screen-reader-text"><?php _e( 'Custom Permalink Structure Tags' ); ?></label><span class="code"><code id="permalink-custom"><?php echo get_option( 'home' ) . $blog_prefix; ?></code><input name="permalink_structure" id="permalink_structure" type="text" value="<?php echo esc_attr( $permalink_structure ); ?>" aria-describedby="permalink-custom" class="regular-text code" /></span></p>
 						<div class="available-structure-tags hide-if-no-js">
 							<div id="custom_selection_updated" aria-live="assertive" class="screen-reader-text"></div>
 							<?php

--- a/src/wp-admin/options-permalink.php
+++ b/src/wp-admin/options-permalink.php
@@ -312,19 +312,23 @@ $structures = array(
 								?>
 								<fieldset>
 									<legend><?php _e( 'Available tags:' ); ?></legend>
+									<ul role="list">
 									<?php
 									foreach ( $available_tags as $tag => $explanation ) {
 										?>
-										<button type="button"
-												class="button button-secondary"
-												aria-label="<?php echo esc_attr( sprintf( $explanation, $tag ) ); ?>"
-												data-added="<?php echo esc_attr( sprintf( $structure_tag_added, $tag ) ); ?>"
-												data-used="<?php echo esc_attr( sprintf( $structure_tag_already_used, $tag ) ); ?>">
-											<?php echo '%' . $tag . '%'; ?>
-										</button>
+										<li>
+											<button type="button"
+													class="button button-secondary"
+													aria-label="<?php echo esc_attr( sprintf( $explanation, $tag ) ); ?>"
+													data-added="<?php echo esc_attr( sprintf( $structure_tag_added, $tag ) ); ?>"
+													data-used="<?php echo esc_attr( sprintf( $structure_tag_already_used, $tag ) ); ?>">
+												<?php echo '%' . $tag . '%'; ?>
+											</button>
+										</li>
 										<?php
 									}
 									?>
+									</ul>
 								</fieldset>
 							<?php endif; ?>
 						</div>

--- a/src/wp-admin/options-permalink.php
+++ b/src/wp-admin/options-permalink.php
@@ -244,29 +244,29 @@ $structures = array(
 			<td>
 				<fieldset class="structure-selection">
 					<legend class="screen-reader-text"><?php _e( 'Select permalink structure' ); ?></legend>
-					<label for="permalink-input-plain">
-						<input id="permalink-input-plain" name="selection" aria-describedby="permalink-plain" type="radio" value="" <?php checked( '', $permalink_structure ); ?> /> <?php _e( 'Plain' ); ?>
+					<div>
+						<input id="permalink-input-plain" name="selection" aria-describedby="permalink-plain" type="radio" value="" <?php checked( '', $permalink_structure ); ?> /> <label for="permalink-input-plain"><?php _e( 'Plain' ); ?></label>
 						<p class="description"><code id="permalink-plain"><?php echo get_option( 'home' ); ?>/?p=123</code></p>
-					</label><br />
-					<label for="permalink-input-day-name">
-						<input id="permalink-input-day-name" name="selection" aria-describedby="permalink-day-name" type="radio" value="<?php echo esc_attr( $structures[1] ); ?>" <?php checked( $structures[1], $permalink_structure ); ?> /> <?php _e( 'Day and name' ); ?>
+					</div>
+					<div>
+						<input id="permalink-input-day-name" name="selection" aria-describedby="permalink-day-name" type="radio" value="<?php echo esc_attr( $structures[1] ); ?>" <?php checked( $structures[1], $permalink_structure ); ?> /> <label for="permalink-input-day-name"><?php _e( 'Day and name' ); ?></label>
 						<p class="description"><code id="permalink-day-name"><?php echo get_option( 'home' ) . $blog_prefix . $prefix . '/' . gmdate( 'Y' ) . '/' . gmdate( 'm' ) . '/' . gmdate( 'd' ) . '/' . _x( 'sample-post', 'sample permalink structure' ) . '/'; ?></code></p>
-						</label><br />
-					<label for="permalink-input-month-name">
-						<input id="permalink-input-month-name" name="selection" aria-describedby="permalink-month-name" type="radio" value="<?php echo esc_attr( $structures[2] ); ?>" <?php checked( $structures[2], $permalink_structure ); ?> /> <?php _e( 'Month and name' ); ?>
+					</div>
+					<div>
+						<input id="permalink-input-month-name" name="selection" aria-describedby="permalink-month-name" type="radio" value="<?php echo esc_attr( $structures[2] ); ?>" <?php checked( $structures[2], $permalink_structure ); ?> /> <label for="permalink-input-month-name"><?php _e( 'Month and name' ); ?></label>
 						<p class="description"><code id="permalink-month-name"><?php echo get_option( 'home' ) . $blog_prefix . $prefix . '/' . gmdate( 'Y' ) . '/' . gmdate( 'm' ) . '/' . _x( 'sample-post', 'sample permalink structure' ) . '/'; ?></code></p>
-					</label><br />
-					<label for="permalink-input-numeric">
-						<input id="permalink-input-numeric" name="selection" aria-describedby="permalink-numeric" type="radio" value="<?php echo esc_attr( $structures[3] ); ?>" <?php checked( $structures[3], $permalink_structure ); ?> /> <?php _e( 'Numeric' ); ?>
+					</div>
+					<div>
+						<input id="permalink-input-numeric" name="selection" aria-describedby="permalink-numeric" type="radio" value="<?php echo esc_attr( $structures[3] ); ?>" <?php checked( $structures[3], $permalink_structure ); ?> /> <label for="permalink-input-numeric"><?php _e( 'Numeric' ); ?></label>
 						<p class="description"><code id="permalink-numeric"><?php echo get_option( 'home' ) . $blog_prefix . $prefix . '/' . _x( 'archives', 'sample permalink base' ) . '/123'; ?></code></p>
-					</label><br />
-					<label for="permalink-input-post-name">
-						<input id="permalink-input-post-name" name="selection" aria-describedby="permalink-post-name" type="radio" value="<?php echo esc_attr( $structures[4] ); ?>" <?php checked( $structures[4], $permalink_structure ); ?> /> <?php _e( 'Post name' ); ?>
+					</div>
+					<div>
+						<input id="permalink-input-post-name" name="selection" aria-describedby="permalink-post-name" type="radio" value="<?php echo esc_attr( $structures[4] ); ?>" <?php checked( $structures[4], $permalink_structure ); ?> /> <label for="permalink-input-post-name"><?php _e( 'Post name' ); ?></label>
 						<p class="description"><code id="permalink-post-name"><?php echo get_option( 'home' ) . $blog_prefix . $prefix . '/' . _x( 'sample-post', 'sample permalink structure' ) . '/'; ?></code></p>
-					</label><br />
-					<label for="custom_selection">
-						<input id="custom_selection" name="selection" aria-describedby="permalink-custom" type="radio" value="custom" <?php checked( ! in_array( $permalink_structure, $structures, true ) ); ?> /> <?php _e( 'Custom Structure' ); ?><br/>
-						<p class="description"><code id="permalink-custom"><?php echo get_option( 'home' ) . $blog_prefix; ?></code><input name="permalink_structure" id="permalink_structure" type="text" value="<?php echo esc_attr( $permalink_structure ); ?>" class="regular-text code" /></p>
+					</div>
+					<div>
+						<input id="custom_selection" name="selection" type="radio" value="custom" <?php checked( ! in_array( $permalink_structure, $structures, true ) ); ?> /> <label for="custom_selection"><?php _e( 'Custom Structure' ); ?></label>
+						<p class="description"><code id="permalink-custom"><?php echo get_option( 'home' ) . $blog_prefix; ?></code><input name="permalink_structure" id="permalink_structure" type="text" value="<?php echo esc_attr( $permalink_structure ); ?>" aria-describedby="permalink-custom" class="regular-text code" /></p>
 						<div class="available-structure-tags hide-if-no-js">
 							<div id="custom_selection_updated" aria-live="assertive" class="screen-reader-text"></div>
 							<?php
@@ -328,7 +328,7 @@ $structures = array(
 								</fieldset>
 							<?php endif; ?>
 						</div>
-					</label><br />
+					</div>
 				</fieldset>
 			</td>
 		</tr>

--- a/src/wp-admin/options-permalink.php
+++ b/src/wp-admin/options-permalink.php
@@ -266,7 +266,7 @@ $structures = array(
 					</div>
 					<div>
 						<input id="custom_selection" name="selection" type="radio" value="custom" <?php checked( ! in_array( $permalink_structure, $structures, true ) ); ?> /> <label for="custom_selection"><?php _e( 'Custom Structure' ); ?></label>
-						<p class="permalink-description"><code id="permalink-custom"><?php echo get_option( 'home' ) . $blog_prefix; ?></code><input name="permalink_structure" id="permalink_structure" type="text" value="<?php echo esc_attr( $permalink_structure ); ?>" aria-describedby="permalink-custom" class="regular-text code" /></p>
+						<p class="permalink-description"><label for="permalink_structure" class="screen-reader-text"><?php _e( 'Custom Permalink Structure Tags' ); ?></label><code id="permalink-custom"><?php echo get_option( 'home' ) . $blog_prefix; ?></code><input name="permalink_structure" id="permalink_structure" type="text" value="<?php echo esc_attr( $permalink_structure ); ?>" aria-describedby="permalink-custom" class="regular-text code" /></p>
 						<div class="available-structure-tags hide-if-no-js">
 							<div id="custom_selection_updated" aria-live="assertive" class="screen-reader-text"></div>
 							<?php

--- a/src/wp-admin/options-permalink.php
+++ b/src/wp-admin/options-permalink.php
@@ -239,10 +239,10 @@ $structures = array(
 <h2 class="title"><?php _e( 'Common Settings' ); ?></h2>
 <table class="form-table permalink-structure" role="presentation">
 	<tbody>
-		<tr class="structure-selection">
+		<tr>
 			<th scope="row"><?php _e( 'Select permalink structure' ); ?></th>
 			<td>
-				<fieldset>
+				<fieldset class="structure-selection">
 					<legend class="screen-reader-text"><span><?php _e( 'Select permalink structure' ); ?></span></legend>
 					<label for="permalink-input-plain">
 						<input id="permalink-input-plain" name="selection" aria-describedby="permalink-plain" type="radio" value="" <?php checked( '', $permalink_structure ); ?> /> <?php _e( 'Plain' ); ?>

--- a/src/wp-admin/options-permalink.php
+++ b/src/wp-admin/options-permalink.php
@@ -310,8 +310,8 @@ $structures = array(
 
 							if ( ! empty( $available_tags ) ) :
 								?>
-								<legend><?php _e( 'Available tags:' ); ?></legend>
 								<fieldset>
+									<legend><?php _e( 'Available tags:' ); ?></legend>
 									<?php
 									foreach ( $available_tags as $tag => $explanation ) {
 										?>

--- a/src/wp-admin/options-permalink.php
+++ b/src/wp-admin/options-permalink.php
@@ -313,21 +313,21 @@ $structures = array(
 								<fieldset>
 									<legend><?php _e( 'Available tags:' ); ?></legend>
 									<ul role="list">
-									<?php
-									foreach ( $available_tags as $tag => $explanation ) {
-										?>
-										<li>
-											<button type="button"
-													class="button button-secondary"
-													aria-label="<?php echo esc_attr( sprintf( $explanation, $tag ) ); ?>"
-													data-added="<?php echo esc_attr( sprintf( $structure_tag_added, $tag ) ); ?>"
-													data-used="<?php echo esc_attr( sprintf( $structure_tag_already_used, $tag ) ); ?>">
-												<?php echo '%' . $tag . '%'; ?>
-											</button>
-										</li>
 										<?php
-									}
-									?>
+										foreach ( $available_tags as $tag => $explanation ) {
+											?>
+											<li>
+												<button type="button"
+														class="button button-secondary"
+														aria-label="<?php echo esc_attr( sprintf( $explanation, $tag ) ); ?>"
+														data-added="<?php echo esc_attr( sprintf( $structure_tag_added, $tag ) ); ?>"
+														data-used="<?php echo esc_attr( sprintf( $structure_tag_already_used, $tag ) ); ?>">
+													<?php echo '%' . $tag . '%'; ?>
+												</button>
+											</li>
+											<?php
+										}
+										?>
 									</ul>
 								</fieldset>
 							<?php endif; ?>

--- a/src/wp-admin/options-permalink.php
+++ b/src/wp-admin/options-permalink.php
@@ -246,27 +246,27 @@ $structures = array(
 					<legend class="screen-reader-text"><?php _e( 'Select permalink structure' ); ?></legend>
 					<div>
 						<input id="permalink-input-plain" name="selection" aria-describedby="permalink-plain" type="radio" value="" <?php checked( '', $permalink_structure ); ?> /> <label for="permalink-input-plain"><?php _e( 'Plain' ); ?></label>
-						<p class="description"><code id="permalink-plain"><?php echo get_option( 'home' ); ?>/?p=123</code></p>
+						<p class="permalink-description"><code id="permalink-plain"><?php echo get_option( 'home' ); ?>/?p=123</code></p>
 					</div>
 					<div>
 						<input id="permalink-input-day-name" name="selection" aria-describedby="permalink-day-name" type="radio" value="<?php echo esc_attr( $structures[1] ); ?>" <?php checked( $structures[1], $permalink_structure ); ?> /> <label for="permalink-input-day-name"><?php _e( 'Day and name' ); ?></label>
-						<p class="description"><code id="permalink-day-name"><?php echo get_option( 'home' ) . $blog_prefix . $prefix . '/' . gmdate( 'Y' ) . '/' . gmdate( 'm' ) . '/' . gmdate( 'd' ) . '/' . _x( 'sample-post', 'sample permalink structure' ) . '/'; ?></code></p>
+						<p class="permalink-description"><code id="permalink-day-name"><?php echo get_option( 'home' ) . $blog_prefix . $prefix . '/' . gmdate( 'Y' ) . '/' . gmdate( 'm' ) . '/' . gmdate( 'd' ) . '/' . _x( 'sample-post', 'sample permalink structure' ) . '/'; ?></code></p>
 					</div>
 					<div>
 						<input id="permalink-input-month-name" name="selection" aria-describedby="permalink-month-name" type="radio" value="<?php echo esc_attr( $structures[2] ); ?>" <?php checked( $structures[2], $permalink_structure ); ?> /> <label for="permalink-input-month-name"><?php _e( 'Month and name' ); ?></label>
-						<p class="description"><code id="permalink-month-name"><?php echo get_option( 'home' ) . $blog_prefix . $prefix . '/' . gmdate( 'Y' ) . '/' . gmdate( 'm' ) . '/' . _x( 'sample-post', 'sample permalink structure' ) . '/'; ?></code></p>
+						<p class="permalink-description"><code id="permalink-month-name"><?php echo get_option( 'home' ) . $blog_prefix . $prefix . '/' . gmdate( 'Y' ) . '/' . gmdate( 'm' ) . '/' . _x( 'sample-post', 'sample permalink structure' ) . '/'; ?></code></p>
 					</div>
 					<div>
 						<input id="permalink-input-numeric" name="selection" aria-describedby="permalink-numeric" type="radio" value="<?php echo esc_attr( $structures[3] ); ?>" <?php checked( $structures[3], $permalink_structure ); ?> /> <label for="permalink-input-numeric"><?php _e( 'Numeric' ); ?></label>
-						<p class="description"><code id="permalink-numeric"><?php echo get_option( 'home' ) . $blog_prefix . $prefix . '/' . _x( 'archives', 'sample permalink base' ) . '/123'; ?></code></p>
+						<p class="permalink-description"><code id="permalink-numeric"><?php echo get_option( 'home' ) . $blog_prefix . $prefix . '/' . _x( 'archives', 'sample permalink base' ) . '/123'; ?></code></p>
 					</div>
 					<div>
 						<input id="permalink-input-post-name" name="selection" aria-describedby="permalink-post-name" type="radio" value="<?php echo esc_attr( $structures[4] ); ?>" <?php checked( $structures[4], $permalink_structure ); ?> /> <label for="permalink-input-post-name"><?php _e( 'Post name' ); ?></label>
-						<p class="description"><code id="permalink-post-name"><?php echo get_option( 'home' ) . $blog_prefix . $prefix . '/' . _x( 'sample-post', 'sample permalink structure' ) . '/'; ?></code></p>
+						<p class="permalink-description"><code id="permalink-post-name"><?php echo get_option( 'home' ) . $blog_prefix . $prefix . '/' . _x( 'sample-post', 'sample permalink structure' ) . '/'; ?></code></p>
 					</div>
 					<div>
 						<input id="custom_selection" name="selection" type="radio" value="custom" <?php checked( ! in_array( $permalink_structure, $structures, true ) ); ?> /> <label for="custom_selection"><?php _e( 'Custom Structure' ); ?></label>
-						<p class="description"><code id="permalink-custom"><?php echo get_option( 'home' ) . $blog_prefix; ?></code><input name="permalink_structure" id="permalink_structure" type="text" value="<?php echo esc_attr( $permalink_structure ); ?>" aria-describedby="permalink-custom" class="regular-text code" /></p>
+						<p class="permalink-description"><code id="permalink-custom"><?php echo get_option( 'home' ) . $blog_prefix; ?></code><input name="permalink_structure" id="permalink_structure" type="text" value="<?php echo esc_attr( $permalink_structure ); ?>" aria-describedby="permalink-custom" class="regular-text code" /></p>
 						<div class="available-structure-tags hide-if-no-js">
 							<div id="custom_selection_updated" aria-live="assertive" class="screen-reader-text"></div>
 							<?php

--- a/src/wp-admin/options-permalink.php
+++ b/src/wp-admin/options-permalink.php
@@ -266,7 +266,7 @@ $structures = array(
 					</div>
 					<div>
 						<input id="custom_selection" name="selection" type="radio" value="custom" <?php checked( ! in_array( $permalink_structure, $structures, true ) ); ?> /> <label for="custom_selection"><?php _e( 'Custom Structure' ); ?></label>
-						<p class="permalink-description"><label for="permalink_structure" class="screen-reader-text"><?php _e( 'Custom Permalink Structure Tags' ); ?></label><span class="code"><code id="permalink-custom"><?php echo get_option( 'home' ) . $blog_prefix; ?></code><input name="permalink_structure" id="permalink_structure" type="text" value="<?php echo esc_attr( $permalink_structure ); ?>" aria-describedby="permalink-custom" class="regular-text code" /></span></p>
+						<p class="permalink-description"><label for="permalink_structure" class="screen-reader-text"><?php _e( 'Customize permalink structure by selecting available tags' ); ?></label><span class="code"><code id="permalink-custom"><?php echo get_option( 'home' ) . $blog_prefix; ?></code><input name="permalink_structure" id="permalink_structure" type="text" value="<?php echo esc_attr( $permalink_structure ); ?>" aria-describedby="permalink-custom" class="regular-text code" /></span></p>
 						<div class="available-structure-tags hide-if-no-js">
 							<div id="custom_selection_updated" aria-live="assertive" class="screen-reader-text"></div>
 							<?php

--- a/src/wp-admin/options-permalink.php
+++ b/src/wp-admin/options-permalink.php
@@ -237,7 +237,7 @@ $structures = array(
 );
 ?>
 <h2 class="title"><?php _e( 'Common Settings' ); ?></h2>
-<table class="form-table permalink-structure">
+<table class="form-table permalink-structure" role="presentation">
 	<tbody>
 		<tr class="structure-selection">
 			<th scope="row"><?php _e( 'Select permalink structure' ); ?></th>

--- a/src/wp-admin/user-new.php
+++ b/src/wp-admin/user-new.php
@@ -112,6 +112,12 @@ if ( isset( $_REQUEST['action'] ) && 'adduser' === $_REQUEST['action'] ) {
 
 			$switched_locale = switch_to_locale( get_user_locale( $user_details ) );
 
+			if ( '' !== get_option( 'blogname' ) ) {
+				$site_title = wp_specialchars_decode( get_option( 'blogname' ), ENT_QUOTES );
+			} else {
+				$site_title = parse_url( home_url(), PHP_URL_HOST );
+			}
+
 			/* translators: 1: Site title, 2: Site URL, 3: User role, 4: Activation URL. */
 			$message = __(
 				'Hi,
@@ -127,7 +133,7 @@ Please click the following link to confirm the invite:
 			$new_user_email['subject'] = sprintf(
 				/* translators: Joining confirmation notification email subject. %s: Site title. */
 				__( '[%s] Joining Confirmation' ),
-				wp_specialchars_decode( get_option( 'blogname' ) )
+				$site_title
 			);
 			$new_user_email['message'] = sprintf(
 				$message,

--- a/src/wp-content/themes/twentytwenty/assets/js/index.js
+++ b/src/wp-content/themes/twentytwenty/assets/js/index.js
@@ -678,20 +678,36 @@ twentytwentyDomReady( function() {
 /* Toggle an attribute ----------------------- */
 
 function twentytwentyToggleAttribute( element, attribute, trueVal, falseVal ) {
-	if ( element.classList.contains( 'close-search-toggle' ) ) {
+	var toggles;
+
+	if ( ! element.hasAttribute( attribute ) ) {
 		return;
 	}
+
 	if ( trueVal === undefined ) {
 		trueVal = true;
 	}
 	if ( falseVal === undefined ) {
 		falseVal = false;
 	}
-	if ( element.getAttribute( attribute ) !== trueVal ) {
-		element.setAttribute( attribute, trueVal );
-	} else {
-		element.setAttribute( attribute, falseVal );
-	}
+
+	/*
+	 * Take into account multiple toggle elements that need their state to be
+	 * synced. For example: the Search toggle buttons for desktop and mobile.
+	 */
+	toggles = document.querySelectorAll( '[data-toggle-target="' + element.dataset.toggleTarget + '"]' );
+
+	toggles.forEach( function( toggle ) {
+		if ( ! toggle.hasAttribute( attribute ) ) {
+			return;
+		}
+
+		if ( toggle.getAttribute( attribute ) !== trueVal ) {
+			toggle.setAttribute( attribute, trueVal );
+		} else {
+			toggle.setAttribute( attribute, falseVal );
+		}
+	} );
 }
 
 /**

--- a/src/wp-content/themes/twentytwenty/template-parts/modal-menu.php
+++ b/src/wp-content/themes/twentytwenty/template-parts/modal-menu.php
@@ -17,7 +17,7 @@
 
 			<div class="menu-top">
 
-				<button class="toggle close-nav-toggle fill-children-current-color" data-toggle-target=".menu-modal" data-toggle-body-class="showing-menu-modal" aria-expanded="false" data-set-focus=".menu-modal">
+				<button class="toggle close-nav-toggle fill-children-current-color" data-toggle-target=".menu-modal" data-toggle-body-class="showing-menu-modal" data-set-focus=".menu-modal">
 					<span class="toggle-text"><?php _e( 'Close Menu', 'twentytwenty' ); ?></span>
 					<?php twentytwenty_the_theme_svg( 'cross' ); ?>
 				</button><!-- .nav-toggle -->

--- a/src/wp-content/themes/twentytwenty/template-parts/modal-search.php
+++ b/src/wp-content/themes/twentytwenty/template-parts/modal-search.php
@@ -8,7 +8,7 @@
  */
 
 ?>
-<div class="search-modal cover-modal header-footer-group" data-modal-target-string=".search-modal">
+<div class="search-modal cover-modal header-footer-group" data-modal-target-string=".search-modal" role="dialog" aria-modal="true" aria-label="<?php esc_attr_e( 'Search', 'twentytwenty' ); ?>">
 
 	<div class="search-modal-inner modal-inner">
 

--- a/src/wp-includes/admin-bar.php
+++ b/src/wp-includes/admin-bar.php
@@ -1233,7 +1233,7 @@ function show_admin_bar( $show ) {
  * @since 3.1.0
  *
  * @global bool   $show_admin_bar
- * @global string $pagenow
+ * @global string $pagenow        The filename of the current screen.
  *
  * @return bool Whether the admin bar should be showing.
  */

--- a/src/wp-includes/block-supports/border.php
+++ b/src/wp-includes/block-supports/border.php
@@ -50,7 +50,7 @@ function wp_register_border_support( $block_type ) {
  * @return array Border CSS classes and inline styles.
  */
 function wp_apply_border_support( $block_type, $block_attributes ) {
-	if ( wp_skip_border_serialization( $block_type ) ) {
+	if ( wp_should_skip_block_supports_serialization( $block_type, 'border' ) ) {
 		return array();
 	}
 
@@ -60,7 +60,8 @@ function wp_apply_border_support( $block_type, $block_attributes ) {
 	// Border radius.
 	if (
 		wp_has_border_feature_support( $block_type, 'radius' ) &&
-		isset( $block_attributes['style']['border']['radius'] )
+		isset( $block_attributes['style']['border']['radius'] ) &&
+		! wp_should_skip_block_supports_serialization( $block_type, '__experimentalBorder', 'radius' )
 	) {
 		$border_radius = $block_attributes['style']['border']['radius'];
 
@@ -84,7 +85,8 @@ function wp_apply_border_support( $block_type, $block_attributes ) {
 	// Border style.
 	if (
 		wp_has_border_feature_support( $block_type, 'style' ) &&
-		isset( $block_attributes['style']['border']['style'] )
+		isset( $block_attributes['style']['border']['style'] ) &&
+		! wp_should_skip_block_supports_serialization( $block_type, '__experimentalBorder', 'style' )
 	) {
 		$border_style = $block_attributes['style']['border']['style'];
 		$styles[]     = sprintf( 'border-style: %s;', $border_style );
@@ -93,7 +95,8 @@ function wp_apply_border_support( $block_type, $block_attributes ) {
 	// Border width.
 	if (
 		wp_has_border_feature_support( $block_type, 'width' ) &&
-		isset( $block_attributes['style']['border']['width'] )
+		isset( $block_attributes['style']['border']['width'] ) &&
+		! wp_should_skip_block_supports_serialization( $block_type, '__experimentalBorder', 'width' )
 	) {
 		$border_width = $block_attributes['style']['border']['width'];
 
@@ -106,7 +109,10 @@ function wp_apply_border_support( $block_type, $block_attributes ) {
 	}
 
 	// Border color.
-	if ( wp_has_border_feature_support( $block_type, 'color' ) ) {
+	if (
+		wp_has_border_feature_support( $block_type, 'color' ) &&
+		! wp_should_skip_block_supports_serialization( $block_type, '__experimentalBorder', 'color' )
+	) {
 		$has_named_border_color  = array_key_exists( 'borderColor', $block_attributes );
 		$has_custom_border_color = isset( $block_attributes['style']['border']['color'] );
 
@@ -134,25 +140,6 @@ function wp_apply_border_support( $block_type, $block_attributes ) {
 	}
 
 	return $attributes;
-}
-
-/**
- * Checks whether serialization of the current block's border properties should
- * occur.
- *
- * @since 5.8.0
- * @access private
- *
- * @param WP_Block_Type $block_type Block type.
- * @return bool Whether serialization of the current block's border properties
- *              should occur.
- */
-function wp_skip_border_serialization( $block_type ) {
-	$border_support = _wp_array_get( $block_type->supports, array( '__experimentalBorder' ), false );
-
-	return is_array( $border_support ) &&
-		array_key_exists( '__experimentalSkipSerialization', $border_support ) &&
-		$border_support['__experimentalSkipSerialization'];
 }
 
 /**

--- a/src/wp-includes/block-supports/colors.php
+++ b/src/wp-includes/block-supports/colors.php
@@ -75,8 +75,7 @@ function wp_apply_colors_support( $block_type, $block_attributes ) {
 
 	if (
 		is_array( $color_support ) &&
-		array_key_exists( '__experimentalSkipSerialization', $color_support ) &&
-		$color_support['__experimentalSkipSerialization']
+		wp_should_skip_block_supports_serialization( $block_type, 'color' )
 	) {
 		return array();
 	}
@@ -89,7 +88,7 @@ function wp_apply_colors_support( $block_type, $block_attributes ) {
 
 	// Text colors.
 	// Check support for text colors.
-	if ( $has_text_colors_support ) {
+	if ( $has_text_colors_support && ! wp_should_skip_block_supports_serialization( $block_type, 'color', 'text' ) ) {
 		$has_named_text_color  = array_key_exists( 'textColor', $block_attributes );
 		$has_custom_text_color = isset( $block_attributes['style']['color']['text'] );
 
@@ -106,7 +105,7 @@ function wp_apply_colors_support( $block_type, $block_attributes ) {
 	}
 
 	// Background colors.
-	if ( $has_background_colors_support ) {
+	if ( $has_background_colors_support && ! wp_should_skip_block_supports_serialization( $block_type, 'color', 'background' ) ) {
 		$has_named_background_color  = array_key_exists( 'backgroundColor', $block_attributes );
 		$has_custom_background_color = isset( $block_attributes['style']['color']['background'] );
 
@@ -123,7 +122,7 @@ function wp_apply_colors_support( $block_type, $block_attributes ) {
 	}
 
 	// Gradients.
-	if ( $has_gradients_support ) {
+	if ( $has_gradients_support && ! wp_should_skip_block_supports_serialization( $block_type, 'color', 'gradients' ) ) {
 		$has_named_gradient  = array_key_exists( 'gradient', $block_attributes );
 		$has_custom_gradient = isset( $block_attributes['style']['color']['gradient'] );
 

--- a/src/wp-includes/block-supports/dimensions.php
+++ b/src/wp-includes/block-supports/dimensions.php
@@ -4,7 +4,7 @@
  *
  * This does not include the `spacing` block support even though that visually
  * appears under the "Dimensions" panel in the editor. It remains in its
- * original `spacing.php` file for backwards compatibility.
+ * original `spacing.php` file for compatibility with core.
  *
  * @package WordPress
  * @since 5.9.0
@@ -51,7 +51,7 @@ function wp_register_dimensions_support( $block_type ) {
  * @return array Block dimensions CSS classes and inline styles.
  */
 function wp_apply_dimensions_support( $block_type, $block_attributes ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
-	if ( wp_skip_dimensions_serialization( $block_type ) ) {
+	if ( wp_should_skip_block_supports_serialization( $block_type, '__experimentalDimensions' ) ) {
 		return array();
 	}
 
@@ -61,23 +61,6 @@ function wp_apply_dimensions_support( $block_type, $block_attributes ) { // phpc
 	// Width support to be added in near future.
 
 	return empty( $styles ) ? array() : array( 'style' => implode( ' ', $styles ) );
-}
-
-/**
- * Checks whether serialization of the current block's dimensions properties
- * should occur.
- *
- * @since 5.9.0
- * @access private
- *
- * @param WP_Block_type $block_type Block type.
- * @return bool Whether to serialize spacing support styles & classes.
- */
-function wp_skip_dimensions_serialization( $block_type ) {
-	$dimensions_support = _wp_array_get( $block_type->supports, array( '__experimentalDimensions' ), false );
-	return is_array( $dimensions_support ) &&
-		array_key_exists( '__experimentalSkipSerialization', $dimensions_support ) &&
-		$dimensions_support['__experimentalSkipSerialization'];
 }
 
 // Register the block support.

--- a/src/wp-includes/block-supports/elements.php
+++ b/src/wp-includes/block-supports/elements.php
@@ -21,6 +21,13 @@ function wp_render_elements_support( $block_content, $block ) {
 		return $block_content;
 	}
 
+	$block_type                    = WP_Block_Type_Registry::get_instance()->get_registered( $block['blockName'] );
+	$skip_link_color_serialization = wp_should_skip_block_supports_serialization( $block_type, 'color', 'link' );
+
+	if ( $skip_link_color_serialization ) {
+		return $block_content;
+	}
+
 	$link_color = null;
 	if ( ! empty( $block['attrs'] ) ) {
 		$link_color = _wp_array_get( $block['attrs'], array( 'style', 'elements', 'link', 'color', 'text' ), null );

--- a/src/wp-includes/block-supports/spacing.php
+++ b/src/wp-includes/block-supports/spacing.php
@@ -44,15 +44,17 @@ function wp_register_spacing_support( $block_type ) {
  * @return array Block spacing CSS classes and inline styles.
  */
 function wp_apply_spacing_support( $block_type, $block_attributes ) {
-	if ( wp_skip_spacing_serialization( $block_type ) ) {
+	if ( wp_should_skip_block_supports_serialization( $block_type, 'spacing' ) ) {
 		return array();
 	}
 
 	$has_padding_support = block_has_support( $block_type, array( 'spacing', 'padding' ), false );
 	$has_margin_support  = block_has_support( $block_type, array( 'spacing', 'margin' ), false );
+	$skip_padding        = wp_should_skip_block_supports_serialization( $block_type, 'spacing', 'padding' );
+	$skip_margin         = wp_should_skip_block_supports_serialization( $block_type, 'spacing', 'margin' );
 	$styles              = array();
 
-	if ( $has_padding_support ) {
+	if ( $has_padding_support && ! $skip_padding ) {
 		$padding_value = _wp_array_get( $block_attributes, array( 'style', 'spacing', 'padding' ), null );
 		if ( is_array( $padding_value ) ) {
 			foreach ( $padding_value as $key => $value ) {
@@ -63,7 +65,7 @@ function wp_apply_spacing_support( $block_type, $block_attributes ) {
 		}
 	}
 
-	if ( $has_margin_support ) {
+	if ( $has_margin_support && ! $skip_margin ) {
 		$margin_value = _wp_array_get( $block_attributes, array( 'style', 'spacing', 'margin' ), null );
 		if ( is_array( $margin_value ) ) {
 			foreach ( $margin_value as $key => $value ) {
@@ -75,24 +77,6 @@ function wp_apply_spacing_support( $block_type, $block_attributes ) {
 	}
 
 	return empty( $styles ) ? array() : array( 'style' => implode( ' ', $styles ) );
-}
-
-/**
- * Checks whether serialization of the current block's spacing properties should
- * occur.
- *
- * @since 5.9.0
- * @access private
- *
- * @param WP_Block_Type $block_type Block type.
- * @return bool Whether to serialize spacing support styles & classes.
- */
-function wp_skip_spacing_serialization( $block_type ) {
-	$spacing_support = _wp_array_get( $block_type->supports, array( 'spacing' ), false );
-
-	return is_array( $spacing_support ) &&
-		array_key_exists( '__experimentalSkipSerialization', $spacing_support ) &&
-		$spacing_support['__experimentalSkipSerialization'];
 }
 
 // Register the block support.

--- a/src/wp-includes/block-supports/typography.php
+++ b/src/wp-includes/block-supports/typography.php
@@ -81,8 +81,7 @@ function wp_apply_typography_support( $block_type, $block_attributes ) {
 		return array();
 	}
 
-	$skip_typography_serialization = _wp_array_get( $typography_supports, array( '__experimentalSkipSerialization' ), false );
-	if ( $skip_typography_serialization ) {
+	if ( wp_should_skip_block_supports_serialization( $block_type, 'typography' ) ) {
 		return array();
 	}
 
@@ -99,7 +98,7 @@ function wp_apply_typography_support( $block_type, $block_attributes ) {
 	$has_text_decoration_support = _wp_array_get( $typography_supports, array( '__experimentalTextDecoration' ), false );
 	$has_text_transform_support  = _wp_array_get( $typography_supports, array( '__experimentalTextTransform' ), false );
 
-	if ( $has_font_size_support ) {
+	if ( $has_font_size_support && ! wp_should_skip_block_supports_serialization( $block_type, 'typography', 'fontSize' ) ) {
 		$has_named_font_size  = array_key_exists( 'fontSize', $block_attributes );
 		$has_custom_font_size = isset( $block_attributes['style']['typography']['fontSize'] );
 
@@ -110,7 +109,7 @@ function wp_apply_typography_support( $block_type, $block_attributes ) {
 		}
 	}
 
-	if ( $has_font_family_support ) {
+	if ( $has_font_family_support && ! wp_should_skip_block_supports_serialization( $block_type, 'typography', 'fontFamily' ) ) {
 		$has_named_font_family  = array_key_exists( 'fontFamily', $block_attributes );
 		$has_custom_font_family = isset( $block_attributes['style']['typography']['fontFamily'] );
 
@@ -129,42 +128,42 @@ function wp_apply_typography_support( $block_type, $block_attributes ) {
 		}
 	}
 
-	if ( $has_font_style_support ) {
+	if ( $has_font_style_support && ! wp_should_skip_block_supports_serialization( $block_type, 'typography', 'fontStyle' ) ) {
 		$font_style = wp_typography_get_css_variable_inline_style( $block_attributes, 'fontStyle', 'font-style' );
 		if ( $font_style ) {
 			$styles[] = $font_style;
 		}
 	}
 
-	if ( $has_font_weight_support ) {
+	if ( $has_font_weight_support && ! wp_should_skip_block_supports_serialization( $block_type, 'typography', 'fontWeight' ) ) {
 		$font_weight = wp_typography_get_css_variable_inline_style( $block_attributes, 'fontWeight', 'font-weight' );
 		if ( $font_weight ) {
 			$styles[] = $font_weight;
 		}
 	}
 
-	if ( $has_line_height_support ) {
+	if ( $has_line_height_support && ! wp_should_skip_block_supports_serialization( $block_type, 'typography', 'lineHeight' ) ) {
 		$has_line_height = isset( $block_attributes['style']['typography']['lineHeight'] );
 		if ( $has_line_height ) {
 			$styles[] = sprintf( 'line-height: %s;', $block_attributes['style']['typography']['lineHeight'] );
 		}
 	}
 
-	if ( $has_text_decoration_support ) {
+	if ( $has_text_decoration_support && ! wp_should_skip_block_supports_serialization( $block_type, 'typography', 'textDecoration' ) ) {
 		$text_decoration_style = wp_typography_get_css_variable_inline_style( $block_attributes, 'textDecoration', 'text-decoration' );
 		if ( $text_decoration_style ) {
 			$styles[] = $text_decoration_style;
 		}
 	}
 
-	if ( $has_text_transform_support ) {
+	if ( $has_text_transform_support && ! wp_should_skip_block_supports_serialization( $block_type, 'typography', 'textTransform' ) ) {
 		$text_transform_style = wp_typography_get_css_variable_inline_style( $block_attributes, 'textTransform', 'text-transform' );
 		if ( $text_transform_style ) {
 			$styles[] = $text_transform_style;
 		}
 	}
 
-	if ( $has_letter_spacing_support ) {
+	if ( $has_letter_spacing_support && ! wp_should_skip_block_supports_serialization( $block_type, 'typography', 'letterSpacing' ) ) {
 		$letter_spacing_style = wp_typography_get_css_variable_inline_style( $block_attributes, 'letterSpacing', 'letter-spacing' );
 		if ( $letter_spacing_style ) {
 			$styles[] = $letter_spacing_style;

--- a/src/wp-includes/block-supports/utils.php
+++ b/src/wp-includes/block-supports/utils.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * Block support utility functions.
+ *
+ * @package WordPress
+ * @subpackage Block Supports
+ * @since 6.0.0
+ */
+
+/**
+ * Checks whether serialization of the current block's supported properties
+ * should occur.
+ *
+ * @since 6.0.0
+ * @access private
+ *
+ * @param WP_Block_Type $block_type  Block type.
+ * @param string        $feature_set Name of block support feature set..
+ * @param string        $feature     Optional name of individual feature to check.
+ *
+ * @return boolean Whether to serialize block support styles & classes.
+ */
+function wp_should_skip_block_supports_serialization( $block_type, $feature_set, $feature = null ) {
+	if ( ! is_object( $block_type ) || ! $feature_set ) {
+		return false;
+	}
+
+	$path               = array( $feature_set, '__experimentalSkipSerialization' );
+	$skip_serialization = _wp_array_get( $block_type->supports, $path, false );
+
+	if ( is_array( $skip_serialization ) ) {
+		return in_array( $feature, $skip_serialization, true );
+	}
+
+	return $skip_serialization;
+}

--- a/src/wp-includes/class-wp-customize-manager.php
+++ b/src/wp-includes/class-wp-customize-manager.php
@@ -500,7 +500,7 @@ final class WP_Customize_Manager {
 	 *
 	 * @since 3.4.0
 	 *
-	 * @global string $pagenow
+	 * @global string $pagenow The filename of the current screen.
 	 */
 	public function setup_theme() {
 		global $pagenow;
@@ -607,7 +607,7 @@ final class WP_Customize_Manager {
 	 *
 	 * @since 4.9.0
 	 *
-	 * @global string $pagenow
+	 * @global string $pagenow The filename of the current screen.
 	 */
 	public function establish_loaded_changeset() {
 		global $pagenow;
@@ -3285,7 +3285,7 @@ final class WP_Customize_Manager {
 	 *
 	 * @since 4.9.0
 	 *
-	 * @global string $pagenow
+	 * @global string $pagenow The filename of the current screen.
 	 *
 	 * @param array $settings Current settings to filter.
 	 * @return array Heartbeat settings.

--- a/src/wp-includes/class-wp-customize-manager.php
+++ b/src/wp-includes/class-wp-customize-manager.php
@@ -3266,6 +3266,7 @@ final class WP_Customize_Manager {
 		if ( ! $changeset_post_id ) {
 			return;
 		}
+
 		$lock = get_post_meta( $changeset_post_id, '_edit_lock', true );
 		$lock = explode( ':', $lock );
 
@@ -3283,14 +3284,19 @@ final class WP_Customize_Manager {
 	 * Filters heartbeat settings for the Customizer.
 	 *
 	 * @since 4.9.0
+	 *
+	 * @global string $pagenow
+	 *
 	 * @param array $settings Current settings to filter.
 	 * @return array Heartbeat settings.
 	 */
 	public function add_customize_screen_to_heartbeat_settings( $settings ) {
 		global $pagenow;
+
 		if ( 'customize.php' === $pagenow ) {
 			$settings['screenId'] = 'customize';
 		}
+
 		return $settings;
 	}
 
@@ -3306,10 +3312,13 @@ final class WP_Customize_Manager {
 		if ( ! $user_id ) {
 			return null;
 		}
+
 		$lock_user = get_userdata( $user_id );
+
 		if ( ! $lock_user ) {
 			return null;
 		}
+
 		return array(
 			'id'     => $lock_user->ID,
 			'name'   => $lock_user->display_name,

--- a/src/wp-includes/class-wp-customize-manager.php
+++ b/src/wp-includes/class-wp-customize-manager.php
@@ -5750,7 +5750,7 @@ final class WP_Customize_Manager {
 				}
 			}
 		}
-		return 0 !== count( get_pages() );
+		return 0 !== count( get_pages( array( 'number' => 1 ) ) );
 	}
 
 	/**

--- a/src/wp-includes/class-wp-customize-manager.php
+++ b/src/wp-includes/class-wp-customize-manager.php
@@ -407,7 +407,7 @@ final class WP_Customize_Manager {
 	}
 
 	/**
-	 * Return true if it's an Ajax request.
+	 * Returns true if it's an Ajax request.
 	 *
 	 * @since 3.4.0
 	 * @since 4.2.0 Added `$action` param.
@@ -476,7 +476,7 @@ final class WP_Customize_Manager {
 	}
 
 	/**
-	 * Return the Ajax wp_die() handler if it's a customized request.
+	 * Returns the Ajax wp_die() handler if it's a customized request.
 	 *
 	 * @since 3.4.0
 	 * @deprecated 4.7.0
@@ -494,7 +494,7 @@ final class WP_Customize_Manager {
 	}
 
 	/**
-	 * Start preview and customize theme.
+	 * Starts preview and customize theme.
 	 *
 	 * Check if customize query variable exist. Init filters to filter the active theme.
 	 *
@@ -597,7 +597,7 @@ final class WP_Customize_Manager {
 	}
 
 	/**
-	 * Establish the loaded changeset.
+	 * Establishes the loaded changeset.
 	 *
 	 * This method runs right at after_setup_theme and applies the 'customize_changeset_branching' filter to determine
 	 * whether concurrent changesets are allowed. Then if the Customizer is not initialized with a `changeset_uuid` param,
@@ -697,7 +697,7 @@ final class WP_Customize_Manager {
 	}
 
 	/**
-	 * Stop previewing the selected theme.
+	 * Stops previewing the selected theme.
 	 *
 	 * Removes filters to change the active theme.
 	 *
@@ -802,7 +802,7 @@ final class WP_Customize_Manager {
 	}
 
 	/**
-	 * Get the changeset UUID.
+	 * Gets the changeset UUID.
 	 *
 	 * @since 4.7.0
 	 *
@@ -818,7 +818,7 @@ final class WP_Customize_Manager {
 	}
 
 	/**
-	 * Get the theme being customized.
+	 * Gets the theme being customized.
 	 *
 	 * @since 3.4.0
 	 *
@@ -832,7 +832,7 @@ final class WP_Customize_Manager {
 	}
 
 	/**
-	 * Get the registered settings.
+	 * Gets the registered settings.
 	 *
 	 * @since 3.4.0
 	 *
@@ -843,7 +843,7 @@ final class WP_Customize_Manager {
 	}
 
 	/**
-	 * Get the registered controls.
+	 * Gets the registered controls.
 	 *
 	 * @since 3.4.0
 	 *
@@ -854,7 +854,7 @@ final class WP_Customize_Manager {
 	}
 
 	/**
-	 * Get the registered containers.
+	 * Gets the registered containers.
 	 *
 	 * @since 4.0.0
 	 *
@@ -865,7 +865,7 @@ final class WP_Customize_Manager {
 	}
 
 	/**
-	 * Get the registered sections.
+	 * Gets the registered sections.
 	 *
 	 * @since 3.4.0
 	 *
@@ -876,7 +876,7 @@ final class WP_Customize_Manager {
 	}
 
 	/**
-	 * Get the registered panels.
+	 * Gets the registered panels.
 	 *
 	 * @since 4.0.0
 	 *
@@ -898,7 +898,7 @@ final class WP_Customize_Manager {
 	}
 
 	/**
-	 * Register styles/scripts and initialize the preview of each setting
+	 * Registers styles/scripts and initialize the preview of each setting
 	 *
 	 * @since 3.4.0
 	 */
@@ -966,7 +966,7 @@ final class WP_Customize_Manager {
 	}
 
 	/**
-	 * Find the changeset post ID for a given changeset UUID.
+	 * Finds the changeset post ID for a given changeset UUID.
 	 *
 	 * @since 4.7.0
 	 *
@@ -1004,7 +1004,7 @@ final class WP_Customize_Manager {
 	}
 
 	/**
-	 * Get changeset posts.
+	 * Gets changeset posts.
 	 *
 	 * @since 4.9.0
 	 *
@@ -1051,7 +1051,7 @@ final class WP_Customize_Manager {
 	}
 
 	/**
-	 * Dismiss all of the current user's auto-drafts (other than the present one).
+	 * Dismisses all of the current user's auto-drafts (other than the present one).
 	 *
 	 * @since 4.9.0
 	 * @return int The number of auto-drafts that were dismissed.
@@ -1077,7 +1077,7 @@ final class WP_Customize_Manager {
 	}
 
 	/**
-	 * Get the changeset post ID for the loaded changeset.
+	 * Gets the changeset post ID for the loaded changeset.
 	 *
 	 * @since 4.7.0
 	 *
@@ -1098,7 +1098,7 @@ final class WP_Customize_Manager {
 	}
 
 	/**
-	 * Get the data stored in a changeset post.
+	 * Gets the data stored in a changeset post.
 	 *
 	 * @since 4.7.0
 	 *
@@ -1132,7 +1132,7 @@ final class WP_Customize_Manager {
 	}
 
 	/**
-	 * Get changeset data.
+	 * Gets changeset data.
 	 *
 	 * @since 4.7.0
 	 * @since 4.9.0 This will return the changeset's data with a user's autosave revision merged on top, if one exists and $autosaved is true.
@@ -1179,7 +1179,7 @@ final class WP_Customize_Manager {
 	protected $pending_starter_content_settings_ids = array();
 
 	/**
-	 * Import theme starter content into the customized state.
+	 * Imports theme starter content into the customized state.
 	 *
 	 * @since 4.7.0
 	 *
@@ -1632,7 +1632,7 @@ final class WP_Customize_Manager {
 	}
 
 	/**
-	 * Prepare starter content attachments.
+	 * Prepares starter content attachments.
 	 *
 	 * Ensure that the attachments are valid and that they have slugs and file name/path.
 	 *
@@ -1694,7 +1694,7 @@ final class WP_Customize_Manager {
 	}
 
 	/**
-	 * Save starter content changeset.
+	 * Saves starter content changeset.
 	 *
 	 * @since 4.7.0
 	 */
@@ -1716,7 +1716,7 @@ final class WP_Customize_Manager {
 	}
 
 	/**
-	 * Get dirty pre-sanitized setting values in the current customized state.
+	 * Gets dirty pre-sanitized setting values in the current customized state.
 	 *
 	 * The returned array consists of a merge of three sources:
 	 * 1. If the theme is not currently active, then the base array is any stashed
@@ -1836,7 +1836,7 @@ final class WP_Customize_Manager {
 	}
 
 	/**
-	 * Override a setting's value in the current customized state.
+	 * Overrides a setting's value in the current customized state.
 	 *
 	 * The name "post_value" is a carry-over from when the customized state was
 	 * exclusively sourced from `$_POST['customized']`.
@@ -1851,7 +1851,7 @@ final class WP_Customize_Manager {
 		$this->_post_values[ $setting_id ] = $value;
 
 		/**
-		 * Announce when a specific setting's unsanitized post value has been set.
+		 * Announces when a specific setting's unsanitized post value has been set.
 		 *
 		 * Fires when the WP_Customize_Manager::set_post_value() method is called.
 		 *
@@ -1865,7 +1865,7 @@ final class WP_Customize_Manager {
 		do_action( "customize_post_value_set_{$setting_id}", $value, $this );
 
 		/**
-		 * Announce when any setting's unsanitized post value has been set.
+		 * Announces when any setting's unsanitized post value has been set.
 		 *
 		 * Fires when the WP_Customize_Manager::set_post_value() method is called.
 		 *
@@ -1882,7 +1882,7 @@ final class WP_Customize_Manager {
 	}
 
 	/**
-	 * Print JavaScript settings.
+	 * Prints JavaScript settings.
 	 *
 	 * @since 3.4.0
 	 */
@@ -1957,7 +1957,7 @@ final class WP_Customize_Manager {
 	}
 
 	/**
-	 * Add customize state query params to a given URL if preview is allowed.
+	 * Adds customize state query params to a given URL if preview is allowed.
 	 *
 	 * @since 4.7.0
 	 *
@@ -2001,7 +2001,7 @@ final class WP_Customize_Manager {
 	}
 
 	/**
-	 * Prevent sending a 404 status when returning the response for the customize
+	 * Prevents sending a 404 status when returning the response for the customize
 	 * preview, since it causes the jQuery Ajax to fail. Send 200 instead.
 	 *
 	 * @since 4.0.0
@@ -2012,7 +2012,7 @@ final class WP_Customize_Manager {
 	}
 
 	/**
-	 * Print base element for preview frame.
+	 * Prints base element for preview frame.
 	 *
 	 * @since 3.4.0
 	 * @deprecated 4.7.0
@@ -2022,7 +2022,7 @@ final class WP_Customize_Manager {
 	}
 
 	/**
-	 * Print a workaround to handle HTML5 tags in IE < 9.
+	 * Prints a workaround to handle HTML5 tags in IE < 9.
 	 *
 	 * @since 3.4.0
 	 * @deprecated 4.7.0 Customizer no longer supports IE8, so all supported browsers recognize HTML5.
@@ -2032,7 +2032,7 @@ final class WP_Customize_Manager {
 	}
 
 	/**
-	 * Print CSS for loading indicators for the Customizer preview.
+	 * Prints CSS for loading indicators for the Customizer preview.
 	 *
 	 * @since 4.2.0
 	 */
@@ -2061,7 +2061,7 @@ final class WP_Customize_Manager {
 	}
 
 	/**
-	 * Remove customize_messenger_channel query parameter from the preview window when it is not in an iframe.
+	 * Removes customize_messenger_channel query parameter from the preview window when it is not in an iframe.
 	 *
 	 * This ensures that the admin bar will be shown. It also ensures that link navigation will
 	 * work as expected since the parent frame is not being sent the URL to navigate to.
@@ -2098,7 +2098,7 @@ final class WP_Customize_Manager {
 	}
 
 	/**
-	 * Print JavaScript settings for preview frame.
+	 * Prints JavaScript settings for preview frame.
 	 *
 	 * @since 3.4.0
 	 */
@@ -2242,7 +2242,7 @@ final class WP_Customize_Manager {
 	}
 
 	/**
-	 * Is it a theme preview?
+	 * Determines whether it is a theme preview or not.
 	 *
 	 * @since 3.4.0
 	 *
@@ -2253,7 +2253,7 @@ final class WP_Customize_Manager {
 	}
 
 	/**
-	 * Retrieve the template name of the previewed theme.
+	 * Retrieves the template name of the previewed theme.
 	 *
 	 * @since 3.4.0
 	 *
@@ -2264,7 +2264,7 @@ final class WP_Customize_Manager {
 	}
 
 	/**
-	 * Retrieve the stylesheet name of the previewed theme.
+	 * Retrieves the stylesheet name of the previewed theme.
 	 *
 	 * @since 3.4.0
 	 *
@@ -2275,7 +2275,7 @@ final class WP_Customize_Manager {
 	}
 
 	/**
-	 * Retrieve the template root of the previewed theme.
+	 * Retrieves the template root of the previewed theme.
 	 *
 	 * @since 3.4.0
 	 *
@@ -2286,7 +2286,7 @@ final class WP_Customize_Manager {
 	}
 
 	/**
-	 * Retrieve the stylesheet root of the previewed theme.
+	 * Retrieves the stylesheet root of the previewed theme.
 	 *
 	 * @since 3.4.0
 	 *
@@ -2408,7 +2408,7 @@ final class WP_Customize_Manager {
 	}
 
 	/**
-	 * Handle customize_save WP Ajax request to save/update a changeset.
+	 * Handles customize_save WP Ajax request to save/update a changeset.
 	 *
 	 * @since 3.4.0
 	 * @since 4.7.0 The semantics of this method have changed to update a changeset, optionally to also change the status and other attributes.
@@ -2604,7 +2604,7 @@ final class WP_Customize_Manager {
 	}
 
 	/**
-	 * Save the post for the loaded changeset.
+	 * Saves the post for the loaded changeset.
 	 *
 	 * @since 4.7.0
 	 *
@@ -2992,7 +2992,7 @@ final class WP_Customize_Manager {
 	}
 
 	/**
-	 * Preserve the initial JSON post_content passed to save into the post.
+	 * Preserves the initial JSON post_content passed to save into the post.
 	 *
 	 * This is needed to prevent KSES and other {@see 'content_save_pre'} filters
 	 * from corrupting JSON data.
@@ -3037,7 +3037,7 @@ final class WP_Customize_Manager {
 	}
 
 	/**
-	 * Trash or delete a changeset post.
+	 * Trashes or deletes a changeset post.
 	 *
 	 * The following re-formulates the logic from `wp_trash_post()` as done in
 	 * `wp_publish_post()`. The reason for bypassing `wp_trash_post()` is that it
@@ -3116,7 +3116,7 @@ final class WP_Customize_Manager {
 	}
 
 	/**
-	 * Handle request to trash a changeset.
+	 * Handles request to trash a changeset.
 	 *
 	 * @since 4.9.0
 	 */
@@ -3201,7 +3201,7 @@ final class WP_Customize_Manager {
 	}
 
 	/**
-	 * Re-map 'edit_post' meta cap for a customize_changeset post to be the same as 'customize' maps.
+	 * Re-maps 'edit_post' meta cap for a customize_changeset post to be the same as 'customize' maps.
 	 *
 	 * There is essentially a "meta meta" cap in play here, where 'edit_post' meta cap maps to
 	 * the 'customize' meta cap which then maps to 'edit_theme_options'. This is currently
@@ -3295,7 +3295,7 @@ final class WP_Customize_Manager {
 	}
 
 	/**
-	 * Get lock user data.
+	 * Gets lock user data.
 	 *
 	 * @since 4.9.0
 	 *
@@ -3318,7 +3318,7 @@ final class WP_Customize_Manager {
 	}
 
 	/**
-	 * Check locked changeset with heartbeat API.
+	 * Checks locked changeset with heartbeat API.
 	 *
 	 * @since 4.9.0
 	 *
@@ -3399,7 +3399,7 @@ final class WP_Customize_Manager {
 	}
 
 	/**
-	 * Whether a changeset revision should be made.
+	 * Determines whether a changeset revision should be made.
 	 *
 	 * @since 4.7.0
 	 * @var bool
@@ -3427,9 +3427,9 @@ final class WP_Customize_Manager {
 	}
 
 	/**
-	 * Publish changeset values.
+	 * Publishes the values of a changeset.
 	 *
-	 * This will the values contained in a changeset, even changesets that do not
+	 * This will publish the values contained in a changeset, even changesets that do not
 	 * correspond to current manager instance. This is called by
 	 * `_wp_customize_publish_changeset()` when a customize_changeset post is
 	 * transitioned to the `publish` status. As such, this method should not be
@@ -3617,7 +3617,7 @@ final class WP_Customize_Manager {
 	}
 
 	/**
-	 * Update stashed theme mod settings.
+	 * Updates stashed theme mod settings.
 	 *
 	 * @since 4.7.0
 	 *
@@ -3654,7 +3654,7 @@ final class WP_Customize_Manager {
 	}
 
 	/**
-	 * Refresh nonces for the current preview.
+	 * Refreshes nonces for the current preview.
 	 *
 	 * @since 4.2.0
 	 */
@@ -3667,7 +3667,7 @@ final class WP_Customize_Manager {
 	}
 
 	/**
-	 * Delete a given auto-draft changeset or the autosave revision for a given changeset or delete changeset lock.
+	 * Deletes a given auto-draft changeset or the autosave revision for a given changeset or delete changeset lock.
 	 *
 	 * @since 4.9.0
 	 */
@@ -3735,7 +3735,7 @@ final class WP_Customize_Manager {
 	}
 
 	/**
-	 * Add a customize setting.
+	 * Adds a customize setting.
 	 *
 	 * @since 3.4.0
 	 * @since 4.5.0 Return added WP_Customize_Setting instance.
@@ -3769,7 +3769,7 @@ final class WP_Customize_Manager {
 	}
 
 	/**
-	 * Register any dynamically-created settings, such as those from $_POST['customized']
+	 * Registers any dynamically-created settings, such as those from $_POST['customized']
 	 * that have no corresponding setting created.
 	 *
 	 * This is a mechanism to "wake up" settings that have been dynamically created
@@ -3830,7 +3830,7 @@ final class WP_Customize_Manager {
 	}
 
 	/**
-	 * Retrieve a customize setting.
+	 * Retrieves a customize setting.
 	 *
 	 * @since 3.4.0
 	 *
@@ -3844,7 +3844,7 @@ final class WP_Customize_Manager {
 	}
 
 	/**
-	 * Remove a customize setting.
+	 * Removes a customize setting.
 	 *
 	 * Note that removing the setting doesn't destroy the WP_Customize_Setting instance or remove its filters.
 	 *
@@ -3857,7 +3857,7 @@ final class WP_Customize_Manager {
 	}
 
 	/**
-	 * Add a customize panel.
+	 * Adds a customize panel.
 	 *
 	 * @since 4.0.0
 	 * @since 4.5.0 Return added WP_Customize_Panel instance.
@@ -3882,7 +3882,7 @@ final class WP_Customize_Manager {
 	}
 
 	/**
-	 * Retrieve a customize panel.
+	 * Retrieves a customize panel.
 	 *
 	 * @since 4.0.0
 	 *
@@ -3896,7 +3896,7 @@ final class WP_Customize_Manager {
 	}
 
 	/**
-	 * Remove a customize panel.
+	 * Removes a customize panel.
 	 *
 	 * Note that removing the panel doesn't destroy the WP_Customize_Panel instance or remove its filters.
 	 *
@@ -3926,7 +3926,7 @@ final class WP_Customize_Manager {
 	}
 
 	/**
-	 * Register a customize panel type.
+	 * Registers a customize panel type.
 	 *
 	 * Registered types are eligible to be rendered via JS and created dynamically.
 	 *
@@ -3941,7 +3941,7 @@ final class WP_Customize_Manager {
 	}
 
 	/**
-	 * Render JS templates for all registered panel types.
+	 * Renders JS templates for all registered panel types.
 	 *
 	 * @since 4.3.0
 	 */
@@ -3953,7 +3953,7 @@ final class WP_Customize_Manager {
 	}
 
 	/**
-	 * Add a customize section.
+	 * Adds a customize section.
 	 *
 	 * @since 3.4.0
 	 * @since 4.5.0 Return added WP_Customize_Section instance.
@@ -3978,7 +3978,7 @@ final class WP_Customize_Manager {
 	}
 
 	/**
-	 * Retrieve a customize section.
+	 * Retrieves a customize section.
 	 *
 	 * @since 3.4.0
 	 *
@@ -3992,7 +3992,7 @@ final class WP_Customize_Manager {
 	}
 
 	/**
-	 * Remove a customize section.
+	 * Removes a customize section.
 	 *
 	 * Note that removing the section doesn't destroy the WP_Customize_Section instance or remove its filters.
 	 *
@@ -4005,7 +4005,7 @@ final class WP_Customize_Manager {
 	}
 
 	/**
-	 * Register a customize section type.
+	 * Registers a customize section type.
 	 *
 	 * Registered types are eligible to be rendered via JS and created dynamically.
 	 *
@@ -4020,7 +4020,7 @@ final class WP_Customize_Manager {
 	}
 
 	/**
-	 * Render JS templates for all registered section types.
+	 * Renders JS templates for all registered section types.
 	 *
 	 * @since 4.3.0
 	 */
@@ -4032,7 +4032,7 @@ final class WP_Customize_Manager {
 	}
 
 	/**
-	 * Add a customize control.
+	 * Adds a customize control.
 	 *
 	 * @since 3.4.0
 	 * @since 4.5.0 Return added WP_Customize_Control instance.
@@ -4057,7 +4057,7 @@ final class WP_Customize_Manager {
 	}
 
 	/**
-	 * Retrieve a customize control.
+	 * Retrieves a customize control.
 	 *
 	 * @since 3.4.0
 	 *
@@ -4071,7 +4071,7 @@ final class WP_Customize_Manager {
 	}
 
 	/**
-	 * Remove a customize control.
+	 * Removes a customize control.
 	 *
 	 * Note that removing the control doesn't destroy the WP_Customize_Control instance or remove its filters.
 	 *
@@ -4084,7 +4084,7 @@ final class WP_Customize_Manager {
 	}
 
 	/**
-	 * Register a customize control type.
+	 * Registers a customize control type.
 	 *
 	 * Registered types are eligible to be rendered via JS and created dynamically.
 	 *
@@ -4098,7 +4098,7 @@ final class WP_Customize_Manager {
 	}
 
 	/**
-	 * Render JS templates for all registered control types.
+	 * Renders JS templates for all registered control types.
 	 *
 	 * @since 4.1.0
 	 */
@@ -4388,7 +4388,7 @@ final class WP_Customize_Manager {
 	}
 
 	/**
-	 * Prepare panels, sections, and controls.
+	 * Prepares panels, sections, and controls.
 	 *
 	 * For each, check if required related components exist,
 	 * whether the user has the necessary capabilities,
@@ -4500,7 +4500,7 @@ final class WP_Customize_Manager {
 	}
 
 	/**
-	 * Enqueue scripts for customize controls.
+	 * Enqueues scripts for customize controls.
 	 *
 	 * @since 3.4.0
 	 */
@@ -4522,7 +4522,7 @@ final class WP_Customize_Manager {
 	}
 
 	/**
-	 * Determine whether the user agent is iOS.
+	 * Determines whether the user agent is iOS.
 	 *
 	 * @since 4.4.0
 	 *
@@ -4533,7 +4533,7 @@ final class WP_Customize_Manager {
 	}
 
 	/**
-	 * Get the template string for the Customizer pane document title.
+	 * Gets the template string for the Customizer pane document title.
 	 *
 	 * @since 4.4.0
 	 *
@@ -4552,7 +4552,7 @@ final class WP_Customize_Manager {
 	}
 
 	/**
-	 * Set the initial URL to be previewed.
+	 * Sets the initial URL to be previewed.
 	 *
 	 * URL is validated.
 	 *
@@ -4566,7 +4566,7 @@ final class WP_Customize_Manager {
 	}
 
 	/**
-	 * Get the initial URL to be previewed.
+	 * Gets the initial URL to be previewed.
 	 *
 	 * @since 4.4.0
 	 *
@@ -4596,7 +4596,7 @@ final class WP_Customize_Manager {
 	}
 
 	/**
-	 * Get URLs allowed to be previewed.
+	 * Gets URLs allowed to be previewed.
 	 *
 	 * If the front end and the admin are served from the same domain, load the
 	 * preview over ssl if the Customizer is being loaded over ssl. This avoids
@@ -4629,7 +4629,7 @@ final class WP_Customize_Manager {
 	}
 
 	/**
-	 * Get messenger channel.
+	 * Gets messenger channel.
 	 *
 	 * @since 4.7.0
 	 *
@@ -4640,7 +4640,7 @@ final class WP_Customize_Manager {
 	}
 
 	/**
-	 * Set URL to link the user to when closing the Customizer.
+	 * Sets URL to link the user to when closing the Customizer.
 	 *
 	 * URL is validated.
 	 *
@@ -4656,7 +4656,7 @@ final class WP_Customize_Manager {
 	}
 
 	/**
-	 * Get URL to link the user to when closing the Customizer.
+	 * Gets URL to link the user to when closing the Customizer.
 	 *
 	 * @since 4.4.0
 	 *
@@ -4699,7 +4699,7 @@ final class WP_Customize_Manager {
 	}
 
 	/**
-	 * Set the autofocused constructs.
+	 * Sets the autofocused constructs.
 	 *
 	 * @since 4.4.0
 	 *
@@ -4716,7 +4716,7 @@ final class WP_Customize_Manager {
 	}
 
 	/**
-	 * Get the autofocused constructs.
+	 * Gets the autofocused constructs.
 	 *
 	 * @since 4.4.0
 	 *
@@ -4733,7 +4733,7 @@ final class WP_Customize_Manager {
 	}
 
 	/**
-	 * Get nonces for the Customizer.
+	 * Gets nonces for the Customizer.
 	 *
 	 * @since 4.5.0
 	 *
@@ -4764,7 +4764,7 @@ final class WP_Customize_Manager {
 	}
 
 	/**
-	 * Print JavaScript settings for parent window.
+	 * Prints JavaScript settings for parent window.
 	 *
 	 * @since 4.4.0
 	 */
@@ -5014,7 +5014,7 @@ final class WP_Customize_Manager {
 	}
 
 	/**
-	 * Register some default controls.
+	 * Registers some default controls.
 	 *
 	 * @since 3.4.0
 	 */
@@ -5732,7 +5732,7 @@ final class WP_Customize_Manager {
 	}
 
 	/**
-	 * Return whether there are published pages.
+	 * Returns whether there are published pages.
 	 *
 	 * Used as active callback for static front page section and controls.
 	 *
@@ -5754,7 +5754,7 @@ final class WP_Customize_Manager {
 	}
 
 	/**
-	 * Add settings from the POST data that were not added with code, e.g. dynamically-created settings for Widgets
+	 * Adds settings from the POST data that were not added with code, e.g. dynamically-created settings for Widgets
 	 *
 	 * @since 4.2.0
 	 *
@@ -5766,7 +5766,7 @@ final class WP_Customize_Manager {
 	}
 
 	/**
-	 * Load themes into the theme browsing/installation UI.
+	 * Loads themes into the theme browsing/installation UI.
 	 *
 	 * @since 4.9.0
 	 */
@@ -6001,7 +6001,7 @@ final class WP_Customize_Manager {
 	}
 
 	/**
-	 * Export header video settings to facilitate selective refresh.
+	 * Exports header video settings to facilitate selective refresh.
 	 *
 	 * @since 4.7.0
 	 *

--- a/src/wp-includes/class-wp-customize-nav-menus.php
+++ b/src/wp-includes/class-wp-customize-nav-menus.php
@@ -476,7 +476,7 @@ final class WP_Customize_Nav_Menus {
 	}
 
 	/**
-	 * Enqueue scripts and styles for Customizer pane.
+	 * Enqueues scripts and styles for Customizer pane.
 	 *
 	 * @since 4.3.0
 	 */
@@ -598,7 +598,7 @@ final class WP_Customize_Nav_Menus {
 	}
 
 	/**
-	 * Allow non-statically created settings to be constructed with custom WP_Customize_Setting subclass.
+	 * Allows non-statically created settings to be constructed with custom WP_Customize_Setting subclass.
 	 *
 	 * @since 4.3.0
 	 *
@@ -619,7 +619,7 @@ final class WP_Customize_Nav_Menus {
 	}
 
 	/**
-	 * Add the customizer settings and controls.
+	 * Adds the customizer settings and controls.
 	 *
 	 * @since 4.3.0
 	 */
@@ -863,7 +863,7 @@ final class WP_Customize_Nav_Menus {
 	}
 
 	/**
-	 * Get the base10 intval.
+	 * Gets the base10 intval.
 	 *
 	 * This is used as a setting's sanitize_callback; we can't use just plain
 	 * intval because the second argument is not what intval() expects.
@@ -878,7 +878,7 @@ final class WP_Customize_Nav_Menus {
 	}
 
 	/**
-	 * Return an array of all the available item types.
+	 * Returns an array of all the available item types.
 	 *
 	 * @since 4.3.0
 	 * @since 4.7.0  Each array item now includes a `$type_label` in addition to `$title`, `$type`, and `$object`.
@@ -929,7 +929,7 @@ final class WP_Customize_Nav_Menus {
 	}
 
 	/**
-	 * Add a new `auto-draft` post.
+	 * Adds a new `auto-draft` post.
 	 *
 	 * @since 4.7.0
 	 *
@@ -1056,7 +1056,7 @@ final class WP_Customize_Nav_Menus {
 	}
 
 	/**
-	 * Print the JavaScript templates used to render Menu Customizer components.
+	 * Prints the JavaScript templates used to render Menu Customizer components.
 	 *
 	 * Templates are imported into the JS use wp.template.
 	 *
@@ -1134,7 +1134,7 @@ final class WP_Customize_Nav_Menus {
 	}
 
 	/**
-	 * Print the HTML template used to render the add-menu-item frame.
+	 * Prints the HTML template used to render the add-menu-item frame.
 	 *
 	 * @since 4.3.0
 	 */
@@ -1192,7 +1192,7 @@ final class WP_Customize_Nav_Menus {
 	}
 
 	/**
-	 * Print the markup for new menu items.
+	 * Prints the markup for new menu items.
 	 *
 	 * To be used in the template #available-menu-items.
 	 *
@@ -1237,7 +1237,7 @@ final class WP_Customize_Nav_Menus {
 	}
 
 	/**
-	 * Print the markup for available menu item custom links.
+	 * Prints the markup for available menu item custom links.
 	 *
 	 * @since 4.7.0
 	 *
@@ -1317,7 +1317,7 @@ final class WP_Customize_Nav_Menus {
 	}
 
 	/**
-	 * Add hooks for the Customizer preview.
+	 * Adds hooks for the Customizer preview.
 	 *
 	 * @since 4.3.0
 	 */
@@ -1330,7 +1330,7 @@ final class WP_Customize_Nav_Menus {
 	}
 
 	/**
-	 * Make the auto-draft status protected so that it can be queried.
+	 * Makes the auto-draft status protected so that it can be queried.
 	 *
 	 * @since 4.7.0
 	 *
@@ -1342,7 +1342,7 @@ final class WP_Customize_Nav_Menus {
 	}
 
 	/**
-	 * Sanitize post IDs for posts created for nav menu items to be published.
+	 * Sanitizes post IDs for posts created for nav menu items to be published.
 	 *
 	 * @since 4.7.0
 	 *
@@ -1372,7 +1372,7 @@ final class WP_Customize_Nav_Menus {
 	}
 
 	/**
-	 * Publish the auto-draft posts that were created for nav menu items.
+	 * Publishes the auto-draft posts that were created for nav menu items.
 	 *
 	 * The post IDs will have been sanitized by already by
 	 * `WP_Customize_Nav_Menu_Items::sanitize_nav_menus_created_posts()` to
@@ -1413,7 +1413,7 @@ final class WP_Customize_Nav_Menus {
 	}
 
 	/**
-	 * Keep track of the arguments that are being passed to wp_nav_menu().
+	 * Keeps track of the arguments that are being passed to wp_nav_menu().
 	 *
 	 * @since 4.3.0
 	 *
@@ -1517,7 +1517,7 @@ final class WP_Customize_Nav_Menus {
 	}
 
 	/**
-	 * Enqueue scripts for the Customizer preview.
+	 * Enqueues scripts for the Customizer preview.
 	 *
 	 * @since 4.3.0
 	 */
@@ -1540,7 +1540,7 @@ final class WP_Customize_Nav_Menus {
 	}
 
 	/**
-	 * Export any wp_nav_menu() calls during the rendering of any partials.
+	 * Exports any wp_nav_menu() calls during the rendering of any partials.
 	 *
 	 * @since 4.5.0
 	 *
@@ -1553,7 +1553,7 @@ final class WP_Customize_Nav_Menus {
 	}
 
 	/**
-	 * Render a specific menu via wp_nav_menu() using the supplied arguments.
+	 * Renders a specific menu via wp_nav_menu() using the supplied arguments.
 	 *
 	 * @since 4.3.0
 	 *

--- a/src/wp-includes/class-wp-post-type.php
+++ b/src/wp-includes/class-wp-post-type.php
@@ -45,6 +45,14 @@ final class WP_Post_Type {
 	public $labels;
 
 	/**
+	 * Default labels.
+	 *
+	 * @since 6.0.0
+	 * @var (string|null)[][] $default_labels
+	 */
+	protected static $default_labels = array();
+
+	/**
 	 * A short descriptive summary of what the post type is.
 	 *
 	 * Default empty.
@@ -784,5 +792,70 @@ final class WP_Post_Type {
 		}
 
 		return $this->rest_controller;
+	}
+
+	/**
+	 * Returns the default labels for post types.
+	 *
+	 * @since 6.0.0
+	 *
+	 * @return (string|null)[][] The default labels for post types.
+	 */
+	public static function get_default_labels() {
+		if ( ! empty( self::$default_labels ) ) {
+			return self::$default_labels;
+		}
+
+		self::$default_labels = array(
+			'name'                     => array( _x( 'Posts', 'post type general name' ), _x( 'Pages', 'post type general name' ) ),
+			'singular_name'            => array( _x( 'Post', 'post type singular name' ), _x( 'Page', 'post type singular name' ) ),
+			'add_new'                  => array( _x( 'Add New', 'post' ), _x( 'Add New', 'page' ) ),
+			'add_new_item'             => array( __( 'Add New Post' ), __( 'Add New Page' ) ),
+			'edit_item'                => array( __( 'Edit Post' ), __( 'Edit Page' ) ),
+			'new_item'                 => array( __( 'New Post' ), __( 'New Page' ) ),
+			'view_item'                => array( __( 'View Post' ), __( 'View Page' ) ),
+			'view_items'               => array( __( 'View Posts' ), __( 'View Pages' ) ),
+			'search_items'             => array( __( 'Search Posts' ), __( 'Search Pages' ) ),
+			'not_found'                => array( __( 'No posts found.' ), __( 'No pages found.' ) ),
+			'not_found_in_trash'       => array( __( 'No posts found in Trash.' ), __( 'No pages found in Trash.' ) ),
+			'parent_item_colon'        => array( null, __( 'Parent Page:' ) ),
+			'all_items'                => array( __( 'All Posts' ), __( 'All Pages' ) ),
+			'archives'                 => array( __( 'Post Archives' ), __( 'Page Archives' ) ),
+			'attributes'               => array( __( 'Post Attributes' ), __( 'Page Attributes' ) ),
+			'insert_into_item'         => array( __( 'Insert into post' ), __( 'Insert into page' ) ),
+			'uploaded_to_this_item'    => array( __( 'Uploaded to this post' ), __( 'Uploaded to this page' ) ),
+			'featured_image'           => array( _x( 'Featured image', 'post' ), _x( 'Featured image', 'page' ) ),
+			'set_featured_image'       => array( _x( 'Set featured image', 'post' ), _x( 'Set featured image', 'page' ) ),
+			'remove_featured_image'    => array( _x( 'Remove featured image', 'post' ), _x( 'Remove featured image', 'page' ) ),
+			'use_featured_image'       => array( _x( 'Use as featured image', 'post' ), _x( 'Use as featured image', 'page' ) ),
+			'filter_items_list'        => array( __( 'Filter posts list' ), __( 'Filter pages list' ) ),
+			'filter_by_date'           => array( __( 'Filter by date' ), __( 'Filter by date' ) ),
+			'items_list_navigation'    => array( __( 'Posts list navigation' ), __( 'Pages list navigation' ) ),
+			'items_list'               => array( __( 'Posts list' ), __( 'Pages list' ) ),
+			'item_published'           => array( __( 'Post published.' ), __( 'Page published.' ) ),
+			'item_published_privately' => array( __( 'Post published privately.' ), __( 'Page published privately.' ) ),
+			'item_reverted_to_draft'   => array( __( 'Post reverted to draft.' ), __( 'Page reverted to draft.' ) ),
+			'item_scheduled'           => array( __( 'Post scheduled.' ), __( 'Page scheduled.' ) ),
+			'item_updated'             => array( __( 'Post updated.' ), __( 'Page updated.' ) ),
+			'item_link'                => array(
+				_x( 'Post Link', 'navigation link block title' ),
+				_x( 'Page Link', 'navigation link block title' ),
+			),
+			'item_link_description'    => array(
+				_x( 'A link to a post.', 'navigation link block description' ),
+				_x( 'A link to a page.', 'navigation link block description' ),
+			),
+		);
+
+		return self::$default_labels;
+	}
+
+	/**
+	 * Resets the cache for the default labels.
+	 *
+	 * @since 6.0.0
+	 */
+	public static function reset_default_labels() {
+		self::$default_labels = array();
 	}
 }

--- a/src/wp-includes/class-wp-query.php
+++ b/src/wp-includes/class-wp-query.php
@@ -2720,10 +2720,22 @@ class WP_Query {
 			$corderby = ( ! empty( $corderby ) ) ? 'ORDER BY ' . $corderby : '';
 			$climits  = ( ! empty( $climits ) ) ? $climits : '';
 
-			$comments = (array) $wpdb->get_results( "SELECT $distinct {$wpdb->comments}.* FROM {$wpdb->comments} $cjoin $cwhere $cgroupby $corderby $climits" );
+			$comments_request = "SELECT $distinct {$wpdb->comments}.comment_ID FROM {$wpdb->comments} $cjoin $cwhere $cgroupby $corderby $climits";
+
+			$key          = md5( $comments_request );
+			$last_changed = wp_cache_get_last_changed( 'comment' ) . ':' . wp_cache_get_last_changed( 'posts' );
+
+			$cache_key   = "comment_feed:$key:$last_changed";
+			$comment_ids = wp_cache_get( $cache_key, 'comment' );
+			if ( false === $comment_ids ) {
+				$comment_ids = $wpdb->get_col( $comments_request );
+				wp_cache_add( $cache_key, $comment_ids, 'comment' );
+			}
+			_prime_comment_caches( $comment_ids, false );
+
 			// Convert to WP_Comment.
 			/** @var WP_Comment[] */
-			$this->comments      = array_map( 'get_comment', $comments );
+			$this->comments      = array_map( 'get_comment', $comment_ids );
 			$this->comment_count = count( $this->comments );
 
 			$post_ids = array();
@@ -3164,11 +3176,22 @@ class WP_Query {
 			/** This filter is documented in wp-includes/query.php */
 			$climits = apply_filters_ref_array( 'comment_feed_limits', array( 'LIMIT ' . get_option( 'posts_per_rss' ), &$this ) );
 
-			$comments_request = "SELECT {$wpdb->comments}.* FROM {$wpdb->comments} $cjoin $cwhere $cgroupby $corderby $climits";
-			$comments         = $wpdb->get_results( $comments_request );
+			$comments_request = "SELECT {$wpdb->comments}.comment_ID FROM {$wpdb->comments} $cjoin $cwhere $cgroupby $corderby $climits";
+
+			$key          = md5( $comments_request );
+			$last_changed = wp_cache_get_last_changed( 'comment' );
+
+			$cache_key   = "comment_feed:$key:$last_changed";
+			$comment_ids = wp_cache_get( $cache_key, 'comment' );
+			if ( false === $comment_ids ) {
+				$comment_ids = $wpdb->get_col( $comments_request );
+				wp_cache_add( $cache_key, $comment_ids, 'comment' );
+			}
+			_prime_comment_caches( $comment_ids, false );
+
 			// Convert to WP_Comment.
 			/** @var WP_Comment[] */
-			$this->comments      = array_map( 'get_comment', $comments );
+			$this->comments      = array_map( 'get_comment', $comment_ids );
 			$this->comment_count = count( $this->comments );
 		}
 

--- a/src/wp-includes/class-wp-recovery-mode-link-service.php
+++ b/src/wp-includes/class-wp-recovery-mode-link-service.php
@@ -65,7 +65,7 @@ class WP_Recovery_Mode_Link_Service {
 	 *
 	 * @since 5.2.0
 	 *
-	 * @global string $pagenow
+	 * @global string $pagenow The filename of the current screen.
 	 *
 	 * @param int $ttl Number of seconds the link should be valid for.
 	 */

--- a/src/wp-includes/class-wp-taxonomy.php
+++ b/src/wp-includes/class-wp-taxonomy.php
@@ -43,6 +43,14 @@ final class WP_Taxonomy {
 	public $labels;
 
 	/**
+	 * Default labels.
+	 *
+	 * @since 6.0.0
+	 * @var (string|null)[][] $default_labels
+	 */
+	protected static $default_labels = array();
+
+	/**
 	 * A short descriptive summary of what the taxonomy is for.
 	 *
 	 * @since 4.7.0
@@ -561,5 +569,72 @@ final class WP_Taxonomy {
 		}
 
 		return $this->rest_controller;
+	}
+
+	/**
+	 * Returns the default labels for taxonomies.
+	 *
+	 * @since 6.0.0
+	 *
+	 * @return (string|null)[][] The default labels for taxonomies.
+	 */
+	public static function get_default_labels() {
+		if ( ! empty( self::$default_labels ) ) {
+			return self::$default_labels;
+		}
+
+		$name_field_description   = __( 'The name is how it appears on your site.' );
+		$slug_field_description   = __( 'The &#8220;slug&#8221; is the URL-friendly version of the name. It is usually all lowercase and contains only letters, numbers, and hyphens.' );
+		$parent_field_description = __( 'Assign a parent term to create a hierarchy. The term Jazz, for example, would be the parent of Bebop and Big Band.' );
+		$desc_field_description   = __( 'The description is not prominent by default; however, some themes may show it.' );
+
+		self::$default_labels = array(
+			'name'                       => array( _x( 'Tags', 'taxonomy general name' ), _x( 'Categories', 'taxonomy general name' ) ),
+			'singular_name'              => array( _x( 'Tag', 'taxonomy singular name' ), _x( 'Category', 'taxonomy singular name' ) ),
+			'search_items'               => array( __( 'Search Tags' ), __( 'Search Categories' ) ),
+			'popular_items'              => array( __( 'Popular Tags' ), null ),
+			'all_items'                  => array( __( 'All Tags' ), __( 'All Categories' ) ),
+			'parent_item'                => array( null, __( 'Parent Category' ) ),
+			'parent_item_colon'          => array( null, __( 'Parent Category:' ) ),
+			'name_field_description'     => array( $name_field_description, $name_field_description ),
+			'slug_field_description'     => array( $slug_field_description, $slug_field_description ),
+			'parent_field_description'   => array( null, $parent_field_description ),
+			'desc_field_description'     => array( $desc_field_description, $desc_field_description ),
+			'edit_item'                  => array( __( 'Edit Tag' ), __( 'Edit Category' ) ),
+			'view_item'                  => array( __( 'View Tag' ), __( 'View Category' ) ),
+			'update_item'                => array( __( 'Update Tag' ), __( 'Update Category' ) ),
+			'add_new_item'               => array( __( 'Add New Tag' ), __( 'Add New Category' ) ),
+			'new_item_name'              => array( __( 'New Tag Name' ), __( 'New Category Name' ) ),
+			'separate_items_with_commas' => array( __( 'Separate tags with commas' ), null ),
+			'add_or_remove_items'        => array( __( 'Add or remove tags' ), null ),
+			'choose_from_most_used'      => array( __( 'Choose from the most used tags' ), null ),
+			'not_found'                  => array( __( 'No tags found.' ), __( 'No categories found.' ) ),
+			'no_terms'                   => array( __( 'No tags' ), __( 'No categories' ) ),
+			'filter_by_item'             => array( null, __( 'Filter by category' ) ),
+			'items_list_navigation'      => array( __( 'Tags list navigation' ), __( 'Categories list navigation' ) ),
+			'items_list'                 => array( __( 'Tags list' ), __( 'Categories list' ) ),
+			/* translators: Tab heading when selecting from the most used terms. */
+			'most_used'                  => array( _x( 'Most Used', 'tags' ), _x( 'Most Used', 'categories' ) ),
+			'back_to_items'              => array( __( '&larr; Go to Tags' ), __( '&larr; Go to Categories' ) ),
+			'item_link'                  => array(
+				_x( 'Tag Link', 'navigation link block title' ),
+				_x( 'Category Link', 'navigation link block title' ),
+			),
+			'item_link_description'      => array(
+				_x( 'A link to a tag.', 'navigation link block description' ),
+				_x( 'A link to a category.', 'navigation link block description' ),
+			),
+		);
+
+		return self::$default_labels;
+	}
+
+	/**
+	 * Resets the cache for the default labels.
+	 *
+	 * @since 6.0.0
+	 */
+	public static function reset_default_labels() {
+		self::$default_labels = array();
 	}
 }

--- a/src/wp-includes/class-wp-theme-json-resolver.php
+++ b/src/wp-includes/class-wp-theme-json-resolver.php
@@ -449,4 +449,32 @@ class WP_Theme_JSON_Resolver {
 		static::$i18n_schema              = null;
 	}
 
+	/**
+	 * Returns the style variations defined by the theme.
+	 *
+	 * @since 6.0.0
+	 *
+	 * @return array
+	 */
+	public static function get_style_variations() {
+		$variations     = array();
+		$base_directory = get_stylesheet_directory() . '/styles';
+		if ( is_dir( $base_directory ) ) {
+			$nested_files      = new RecursiveIteratorIterator( new RecursiveDirectoryIterator( $base_directory ) );
+			$nested_html_files = iterator_to_array( new RegexIterator( $nested_files, '/^.+\.json$/i', RecursiveRegexIterator::GET_MATCH ) );
+			ksort( $nested_html_files );
+			foreach ( $nested_html_files as $path => $file ) {
+				$decoded_file = wp_json_file_decode( $path, array( 'associative' => true ) );
+				if ( is_array( $decoded_file ) ) {
+					$translated = static::translate( $decoded_file, wp_get_theme()->get( 'TextDomain' ) );
+					$variation  = ( new WP_Theme_JSON( $translated ) )->get_raw_data();
+					if ( empty( $variation['title'] ) ) {
+						$variation['title'] = basename( $path, '.json' );
+					}
+					$variations[] = $variation;
+				}
+			}
+		}
+		return $variations;
+	}
 }

--- a/src/wp-includes/embed.php
+++ b/src/wp-includes/embed.php
@@ -328,7 +328,7 @@ function wp_oembed_register_route() {
 }
 
 /**
- * Adds oEmbed discovery links in the website <head>.
+ * Adds oEmbed discovery links in the head element of the website.
  *
  * @since 4.4.0
  */

--- a/src/wp-includes/formatting.php
+++ b/src/wp-includes/formatting.php
@@ -374,8 +374,8 @@ function wptexturize_primes( $haystack, $needle, $prime, $open_quote, $close_quo
  * Searches for disabled element tags. Pushes element to stack on tag open
  * and pops on tag close.
  *
- * Assumes first char of $text is tag opening and last char is tag closing.
- * Assumes second char of $text is optionally '/' to indicate closing as in </html>.
+ * Assumes first char of `$text` is tag opening and last char is tag closing.
+ * Assumes second char of `$text` is optionally `/` to indicate closing as in `</html>`.
  *
  * @since 2.9.0
  * @access private
@@ -429,7 +429,7 @@ function _wptexturize_pushpop_element( $text, &$stack, $disabled_elements ) {
  *
  * A group of regex replaces used to identify text formatted with newlines and
  * replace double line breaks with HTML paragraph tags. The remaining line breaks
- * after conversion become <<br />> tags, unless $br is set to '0' or 'false'.
+ * after conversion become `<br />` tags, unless `$br` is set to '0' or 'false'.
  *
  * @since 0.71
  *
@@ -909,10 +909,10 @@ function seems_utf8( $str ) {
 /**
  * Converts a number of special characters into their HTML entities.
  *
- * Specifically deals with: &, <, >, ", and '.
+ * Specifically deals with: `&`, `<`, `>`, `"`, and `'`.
  *
- * $quote_style can be set to ENT_COMPAT to encode " to
- * &quot;, or ENT_QUOTES to do both. Default is ENT_NOQUOTES where no quotes are encoded.
+ * `$quote_style` can be set to ENT_COMPAT to encode `"` to
+ * `&quot;`, or ENT_QUOTES to do both. Default is ENT_NOQUOTES where no quotes are encoded.
  *
  * @since 1.2.2
  * @since 5.5.0 `$quote_style` also accepts `ENT_XML1`.
@@ -994,10 +994,10 @@ function _wp_specialchars( $string, $quote_style = ENT_NOQUOTES, $charset = fals
 /**
  * Converts a number of HTML entities into their special characters.
  *
- * Specifically deals with: &, <, >, ", and '.
+ * Specifically deals with: `&`, `<`, `>`, `"`, and `'`.
  *
- * $quote_style can be set to ENT_COMPAT to decode " entities,
- * or ENT_QUOTES to do both " and '. Default is ENT_NOQUOTES where no quotes are decoded.
+ * `$quote_style` can be set to ENT_COMPAT to decode `"` entities,
+ * or ENT_QUOTES to do both `"` and `'`. Default is ENT_NOQUOTES where no quotes are decoded.
  *
  * @since 2.8.0
  *
@@ -4510,10 +4510,10 @@ function htmlentities2( $myHTML ) {
 }
 
 /**
- * Escapes single quotes, htmlspecialchar " < > &, and fixes line endings.
+ * Escapes single quotes, `"`, `<`, `>`, `&`, and fixes line endings.
  *
  * Escapes text strings for echoing in JS. It is intended to be used for inline JS
- * (in a tag attribute, for example onclick="..."). Note that the strings have to
+ * (in a tag attribute, for example `onclick="..."`). Note that the strings have to
  * be in single quotes. The {@see 'js_escape'} filter is also applied here.
  *
  * @since 2.8.0

--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -8399,7 +8399,7 @@ function clean_dirsize_cache( $path ) {
  *
  * @since 5.2.0
  *
- * @global string $wp_version WordPress version.
+ * @global string $wp_version The WordPress version string.
  *
  * @param string $required Minimum required WordPress version.
  * @return bool True if required version is compatible or empty, false if not.

--- a/src/wp-includes/functions.wp-scripts.php
+++ b/src/wp-includes/functions.wp-scripts.php
@@ -166,7 +166,7 @@ function wp_add_inline_script( $handle, $data, $position = 'after' ) {
  *                                    as a query string for cache busting purposes. If version is set to false, a version
  *                                    number is automatically added equal to current installed WordPress version.
  *                                    If set to null, no version is added.
- * @param bool             $in_footer Optional. Whether to enqueue the script before </body> instead of in the <head>.
+ * @param bool             $in_footer Optional. Whether to enqueue the script before `</body>` instead of in the `<head>`.
  *                                    Default 'false'.
  * @return bool Whether the script has been registered. True on success, false on failure.
  */
@@ -340,7 +340,7 @@ function wp_deregister_script( $handle ) {
  *                                    as a query string for cache busting purposes. If version is set to false, a version
  *                                    number is automatically added equal to current installed WordPress version.
  *                                    If set to null, no version is added.
- * @param bool             $in_footer Optional. Whether to enqueue the script before </body> instead of in the <head>.
+ * @param bool             $in_footer Optional. Whether to enqueue the script before `</body>` instead of in the `<head>`.
  *                                    Default 'false'.
  */
 function wp_enqueue_script( $handle, $src = '', $deps = array(), $ver = false, $in_footer = false ) {

--- a/src/wp-includes/functions.wp-scripts.php
+++ b/src/wp-includes/functions.wp-scripts.php
@@ -258,7 +258,7 @@ function wp_set_script_translations( $handle, $domain = 'default', $path = null 
  *
  * @since 2.1.0
  *
- * @global string $pagenow
+ * @global string $pagenow The filename of the current screen.
  *
  * @param string $handle Name of the script to be removed.
  */

--- a/src/wp-includes/l10n.php
+++ b/src/wp-includes/l10n.php
@@ -114,7 +114,7 @@ function get_user_locale( $user_id = 0 ) {
  *
  * @since 5.0.0
  *
- * @global string $pagenow
+ * @global string $pagenow The filename of the current screen.
  *
  * @return string The determined locale.
  */

--- a/src/wp-includes/load.php
+++ b/src/wp-includes/load.php
@@ -886,6 +886,8 @@ function wp_skip_paused_plugins( array $plugins ) {
  * @since 5.1.0
  * @access private
  *
+ * @global string $pagenow The filename of the current screen.
+ *
  * @return string[] Array of absolute paths to theme directories.
  */
 function wp_get_active_and_valid_themes() {
@@ -966,7 +968,7 @@ function wp_is_recovery_mode() {
  *
  * @since 5.2.0
  *
- * @global string $pagenow
+ * @global string $pagenow The filename of the current screen.
  *
  * @return bool True if the current endpoint should be protected.
  */
@@ -1746,7 +1748,7 @@ function wp_is_xml_request() {
  *
  * @since 5.6.1
  *
- * @global string $pagenow The current page.
+ * @global string $pagenow The filename of the current screen.
  *
  * @param string $context The context to check for protection. Accepts 'login', 'admin', and 'front'.
  *                        Defaults to the current context.

--- a/src/wp-includes/post.php
+++ b/src/wp-includes/post.php
@@ -6577,7 +6577,7 @@ function wp_update_attachment_metadata( $attachment_id, $data ) {
  *
  * @since 2.1.0
  *
- * @global string $pagenow
+ * @global string $pagenow The filename of the current screen.
  *
  * @param int $attachment_id Optional. Attachment post ID. Defaults to global $post.
  * @return string|false Attachment URL, otherwise false.

--- a/src/wp-includes/post.php
+++ b/src/wp-includes/post.php
@@ -18,6 +18,8 @@
  * @since 2.9.0
  */
 function create_initial_post_types() {
+	WP_Post_Type::reset_default_labels();
+
 	register_post_type(
 		'post',
 		array(
@@ -1955,46 +1957,7 @@ function _post_type_meta_capabilities( $capabilities = null ) {
  * @return object Object with all the labels as member variables.
  */
 function get_post_type_labels( $post_type_object ) {
-	$nohier_vs_hier_defaults = array(
-		'name'                     => array( _x( 'Posts', 'post type general name' ), _x( 'Pages', 'post type general name' ) ),
-		'singular_name'            => array( _x( 'Post', 'post type singular name' ), _x( 'Page', 'post type singular name' ) ),
-		'add_new'                  => array( _x( 'Add New', 'post' ), _x( 'Add New', 'page' ) ),
-		'add_new_item'             => array( __( 'Add New Post' ), __( 'Add New Page' ) ),
-		'edit_item'                => array( __( 'Edit Post' ), __( 'Edit Page' ) ),
-		'new_item'                 => array( __( 'New Post' ), __( 'New Page' ) ),
-		'view_item'                => array( __( 'View Post' ), __( 'View Page' ) ),
-		'view_items'               => array( __( 'View Posts' ), __( 'View Pages' ) ),
-		'search_items'             => array( __( 'Search Posts' ), __( 'Search Pages' ) ),
-		'not_found'                => array( __( 'No posts found.' ), __( 'No pages found.' ) ),
-		'not_found_in_trash'       => array( __( 'No posts found in Trash.' ), __( 'No pages found in Trash.' ) ),
-		'parent_item_colon'        => array( null, __( 'Parent Page:' ) ),
-		'all_items'                => array( __( 'All Posts' ), __( 'All Pages' ) ),
-		'archives'                 => array( __( 'Post Archives' ), __( 'Page Archives' ) ),
-		'attributes'               => array( __( 'Post Attributes' ), __( 'Page Attributes' ) ),
-		'insert_into_item'         => array( __( 'Insert into post' ), __( 'Insert into page' ) ),
-		'uploaded_to_this_item'    => array( __( 'Uploaded to this post' ), __( 'Uploaded to this page' ) ),
-		'featured_image'           => array( _x( 'Featured image', 'post' ), _x( 'Featured image', 'page' ) ),
-		'set_featured_image'       => array( _x( 'Set featured image', 'post' ), _x( 'Set featured image', 'page' ) ),
-		'remove_featured_image'    => array( _x( 'Remove featured image', 'post' ), _x( 'Remove featured image', 'page' ) ),
-		'use_featured_image'       => array( _x( 'Use as featured image', 'post' ), _x( 'Use as featured image', 'page' ) ),
-		'filter_items_list'        => array( __( 'Filter posts list' ), __( 'Filter pages list' ) ),
-		'filter_by_date'           => array( __( 'Filter by date' ), __( 'Filter by date' ) ),
-		'items_list_navigation'    => array( __( 'Posts list navigation' ), __( 'Pages list navigation' ) ),
-		'items_list'               => array( __( 'Posts list' ), __( 'Pages list' ) ),
-		'item_published'           => array( __( 'Post published.' ), __( 'Page published.' ) ),
-		'item_published_privately' => array( __( 'Post published privately.' ), __( 'Page published privately.' ) ),
-		'item_reverted_to_draft'   => array( __( 'Post reverted to draft.' ), __( 'Page reverted to draft.' ) ),
-		'item_scheduled'           => array( __( 'Post scheduled.' ), __( 'Page scheduled.' ) ),
-		'item_updated'             => array( __( 'Post updated.' ), __( 'Page updated.' ) ),
-		'item_link'                => array(
-			_x( 'Post Link', 'navigation link block title' ),
-			_x( 'Page Link', 'navigation link block title' ),
-		),
-		'item_link_description'    => array(
-			_x( 'A link to a post.', 'navigation link block description' ),
-			_x( 'A link to a page.', 'navigation link block description' ),
-		),
-	);
+	$nohier_vs_hier_defaults = WP_Post_Type::get_default_labels();
 
 	$nohier_vs_hier_defaults['menu_name'] = $nohier_vs_hier_defaults['name'];
 

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-global-styles-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-global-styles-controller.php
@@ -582,9 +582,7 @@ class WP_REST_Global_Styles_Controller extends WP_REST_Controller {
 
 		if ( rest_is_field_included( 'styles', $fields ) ) {
 			$raw_data = $theme->get_raw_data();
-			if ( isset( $raw_data['styles'] ) ) {
-				$data['styles'] = $raw_data['styles'];
-			}
+			$data['styles'] = isset( $raw_data['styles'] ) ? $raw_data['styles'] : array();
 		}
 
 		$context = ! empty( $request['context'] ) ? $request['context'] : 'view';

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-global-styles-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-global-styles-controller.php
@@ -38,6 +38,24 @@ class WP_REST_Global_Styles_Controller extends WP_REST_Controller {
 	 * @return void
 	 */
 	public function register_routes() {
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base . '/themes/(?P<stylesheet>[\/\s%\w\.\(\)\[\]\@_\-]+)/variations',
+			array(
+				array(
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'get_theme_items' ),
+					'permission_callback' => array( $this, 'get_theme_items_permissions_check' ),
+					'args'                => array(
+						'stylesheet' => array(
+							'description' => __( 'The theme identifier' ),
+							'type'        => 'string',
+						),
+					),
+				),
+			)
+		);
+
 		// List themes global styles.
 		register_rest_route(
 			$this->namespace,
@@ -582,6 +600,55 @@ class WP_REST_Global_Styles_Controller extends WP_REST_Controller {
 		);
 
 		$response->add_links( $links );
+
+		return $response;
+	}
+
+	/**
+	 * Checks if a given request has access to read a single theme global styles config.
+	 *
+	 * @since 6.0.0
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return true|WP_Error True if the request has read access for the item, WP_Error object otherwise.
+	 */
+	public function get_theme_items_permissions_check( $request ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+		// Verify if the current user has edit_theme_options capability.
+		// This capability is required to edit/view/delete templates.
+		if ( ! current_user_can( 'edit_theme_options' ) ) {
+			return new WP_Error(
+				'rest_cannot_manage_global_styles',
+				__( 'Sorry, you are not allowed to access the global styles on this site.' ),
+				array(
+					'status' => rest_authorization_required_code(),
+				)
+			);
+		}
+
+		return true;
+	}
+
+	/**
+	 * Returns the given theme global styles variations.
+	 *
+	 * @since 6.0.0
+	 *
+	 * @param WP_REST_Request $request The request instance.
+	 *
+	 * @return WP_REST_Response|WP_Error
+	 */
+	public function get_theme_items( $request ) {
+		if ( wp_get_theme()->get_stylesheet() !== $request['stylesheet'] ) {
+			// This endpoint only supports the active theme for now.
+			return new WP_Error(
+				'rest_theme_not_found',
+				__( 'Theme not found.' ),
+				array( 'status' => 404 )
+			);
+		}
+
+		$variations = WP_Theme_JSON_Resolver::get_style_variations();
+		$response   = rest_ensure_response( $variations );
 
 		return $response;
 	}

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-url-details-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-url-details-controller.php
@@ -482,7 +482,7 @@ class WP_REST_URL_Details_Controller extends WP_REST_Controller {
 	}
 
 	/**
-	 * Retrieves the head tag section.
+	 * Retrieves the head element section.
 	 *
 	 * @since 5.9.0
 	 *

--- a/src/wp-includes/script-loader.php
+++ b/src/wp-includes/script-loader.php
@@ -2847,6 +2847,8 @@ function _wp_normalize_relative_css_links( $css, $stylesheet_url ) {
  * Inject the block editor assets that need to be loaded into the editor's iframe as an inline script.
  *
  * @since 5.8.0
+ *
+ * @global string $pagenow The filename of the current screen.
  */
 function wp_add_iframed_editor_assets_html() {
 	global $pagenow;

--- a/src/wp-includes/taxonomy.php
+++ b/src/wp-includes/taxonomy.php
@@ -25,6 +25,8 @@
 function create_initial_taxonomies() {
 	global $wp_rewrite;
 
+	WP_Taxonomy::reset_default_labels();
+
 	if ( ! did_action( 'init' ) ) {
 		$rewrite = array(
 			'category'    => false,
@@ -659,48 +661,7 @@ function get_taxonomy_labels( $tax ) {
 		$tax->labels['not_found'] = $tax->no_tagcloud;
 	}
 
-	$name_field_description   = __( 'The name is how it appears on your site.' );
-	$slug_field_description   = __( 'The &#8220;slug&#8221; is the URL-friendly version of the name. It is usually all lowercase and contains only letters, numbers, and hyphens.' );
-	$parent_field_description = __( 'Assign a parent term to create a hierarchy. The term Jazz, for example, would be the parent of Bebop and Big Band.' );
-	$desc_field_description   = __( 'The description is not prominent by default; however, some themes may show it.' );
-
-	$nohier_vs_hier_defaults = array(
-		'name'                       => array( _x( 'Tags', 'taxonomy general name' ), _x( 'Categories', 'taxonomy general name' ) ),
-		'singular_name'              => array( _x( 'Tag', 'taxonomy singular name' ), _x( 'Category', 'taxonomy singular name' ) ),
-		'search_items'               => array( __( 'Search Tags' ), __( 'Search Categories' ) ),
-		'popular_items'              => array( __( 'Popular Tags' ), null ),
-		'all_items'                  => array( __( 'All Tags' ), __( 'All Categories' ) ),
-		'parent_item'                => array( null, __( 'Parent Category' ) ),
-		'parent_item_colon'          => array( null, __( 'Parent Category:' ) ),
-		'name_field_description'     => array( $name_field_description, $name_field_description ),
-		'slug_field_description'     => array( $slug_field_description, $slug_field_description ),
-		'parent_field_description'   => array( null, $parent_field_description ),
-		'desc_field_description'     => array( $desc_field_description, $desc_field_description ),
-		'edit_item'                  => array( __( 'Edit Tag' ), __( 'Edit Category' ) ),
-		'view_item'                  => array( __( 'View Tag' ), __( 'View Category' ) ),
-		'update_item'                => array( __( 'Update Tag' ), __( 'Update Category' ) ),
-		'add_new_item'               => array( __( 'Add New Tag' ), __( 'Add New Category' ) ),
-		'new_item_name'              => array( __( 'New Tag Name' ), __( 'New Category Name' ) ),
-		'separate_items_with_commas' => array( __( 'Separate tags with commas' ), null ),
-		'add_or_remove_items'        => array( __( 'Add or remove tags' ), null ),
-		'choose_from_most_used'      => array( __( 'Choose from the most used tags' ), null ),
-		'not_found'                  => array( __( 'No tags found.' ), __( 'No categories found.' ) ),
-		'no_terms'                   => array( __( 'No tags' ), __( 'No categories' ) ),
-		'filter_by_item'             => array( null, __( 'Filter by category' ) ),
-		'items_list_navigation'      => array( __( 'Tags list navigation' ), __( 'Categories list navigation' ) ),
-		'items_list'                 => array( __( 'Tags list' ), __( 'Categories list' ) ),
-		/* translators: Tab heading when selecting from the most used terms. */
-		'most_used'                  => array( _x( 'Most Used', 'tags' ), _x( 'Most Used', 'categories' ) ),
-		'back_to_items'              => array( __( '&larr; Go to Tags' ), __( '&larr; Go to Categories' ) ),
-		'item_link'                  => array(
-			_x( 'Tag Link', 'navigation link block title' ),
-			_x( 'Category Link', 'navigation link block title' ),
-		),
-		'item_link_description'      => array(
-			_x( 'A link to a tag.', 'navigation link block description' ),
-			_x( 'A link to a category.', 'navigation link block description' ),
-		),
-	);
+	$nohier_vs_hier_defaults = WP_Taxonomy::get_default_labels();
 
 	$nohier_vs_hier_defaults['menu_name'] = $nohier_vs_hier_defaults['name'];
 

--- a/src/wp-includes/theme.php
+++ b/src/wp-includes/theme.php
@@ -1948,7 +1948,7 @@ function wp_get_custom_css( $stylesheet = '' ) {
 	}
 
 	/**
-	 * Filters the Custom CSS Output into the <head>.
+	 * Filters the custom CSS output into the head element.
 	 *
 	 * @since 4.7.0
 	 *

--- a/src/wp-includes/user.php
+++ b/src/wp-includes/user.php
@@ -3712,7 +3712,7 @@ All at ###SITENAME###
  * @since 3.0.0
  * @since 4.9.0 This function was moved from wp-admin/includes/ms.php so it's no longer Multisite specific.
  *
- * @global string $pagenow
+ * @global string $pagenow The filename of the current screen.
  */
 function new_user_email_admin_notice() {
 	global $pagenow;

--- a/src/wp-includes/vars.php
+++ b/src/wp-includes/vars.php
@@ -2,8 +2,8 @@
 /**
  * Creates common globals for the rest of WordPress
  *
- * Sets $pagenow global which is the current page. Checks
- * for the browser to set which one is currently being used.
+ * Sets $pagenow global which is the filename of the current screen.
+ * Checks for the browser to set which one is currently being used.
  *
  * Detects which user environment WordPress is being used on.
  * Only attempts to check for Apache, Nginx and IIS -- three web

--- a/src/wp-login.php
+++ b/src/wp-login.php
@@ -904,7 +904,17 @@ switch ( $action ) {
 
 		$errors = new WP_Error();
 
-		if ( isset( $_POST['pass1'] ) && $_POST['pass1'] !== $_POST['pass2'] ) {
+		// Check if password is one or all empty spaces.
+		if ( ! empty( $_POST['pass1'] ) ) {
+			$_POST['pass1'] = trim( $_POST['pass1'] );
+
+			if ( empty( $_POST['pass1'] ) ) {
+	  			$errors->add( 'password_reset_empty_space', __( 'The password cannot be a space or all spaces.' ) );
+			}
+  		}
+
+		// Check if password fields do not match.
+		if ( ! empty( $_POST['pass1'] ) && $_POST['pass1'] !== trim( $_POST['pass2'] ) ) {
 			$errors->add( 'password_reset_mismatch', __( '<strong>Error</strong>: The passwords do not match.' ) );
 		}
 

--- a/src/wp-login.php
+++ b/src/wp-login.php
@@ -909,12 +909,12 @@ switch ( $action ) {
 			$_POST['pass1'] = trim( $_POST['pass1'] );
 
 			if ( empty( $_POST['pass1'] ) ) {
-	  			$errors->add( 'password_reset_empty_space', __( 'The password cannot be a space or all spaces.' ) );
+				$errors->add( 'password_reset_empty_space', __( 'The password cannot be a space or all spaces.' ) );
 			}
-  		}
+		}
 
 		// Check if password fields do not match.
-		if ( ! empty( $_POST['pass1'] ) && $_POST['pass1'] !== trim( $_POST['pass2'] ) ) {
+		if ( ! empty( $_POST['pass1'] ) && trim( $_POST['pass2'] ) !== $_POST['pass1'] ) {
 			$errors->add( 'password_reset_mismatch', __( '<strong>Error</strong>: The passwords do not match.' ) );
 		}
 

--- a/src/wp-settings.php
+++ b/src/wp-settings.php
@@ -317,6 +317,7 @@ require ABSPATH . WPINC . '/blocks/index.php';
 require ABSPATH . WPINC . '/block-editor.php';
 require ABSPATH . WPINC . '/block-patterns.php';
 require ABSPATH . WPINC . '/class-wp-block-supports.php';
+require ABSPATH . WPINC . '/block-supports/utils.php';
 require ABSPATH . WPINC . '/block-supports/align.php';
 require ABSPATH . WPINC . '/block-supports/border.php';
 require ABSPATH . WPINC . '/block-supports/colors.php';

--- a/tests/phpunit/data/themedir1/block-theme/styles/variation.json
+++ b/tests/phpunit/data/themedir1/block-theme/styles/variation.json
@@ -1,0 +1,23 @@
+{
+    "version": 2,
+    "settings": {
+        "color": {
+            "palette": [
+                {
+                    "slug": "foreground",
+                    "color": "#3F67C6",
+                    "name": "Foreground"
+                }
+            ]
+        }
+    },
+    "styles": {
+        "blocks": {
+            "core/post-title": {
+                "typography": {
+                    "fontWeight": "700"
+                }
+            }
+        }
+    }
+}

--- a/tests/phpunit/tests/block-supports/border.php
+++ b/tests/phpunit/tests/block-supports/border.php
@@ -1,0 +1,148 @@
+<?php
+/**
+ * @group block-supports
+ */
+class Test_Block_Supports_Border extends WP_UnitTestCase {
+
+	/**
+	 * @ticket 55505
+	 */
+	function test_border_color_slug_with_numbers_is_kebab_cased_properly() {
+		$block_name = 'test/border-color-slug-with-numbers-is-kebab-cased-properly';
+		register_block_type(
+			$block_name,
+			array(
+				'api_version' => 2,
+				'attributes'  => array(
+					'borderColor' => array(
+						'type' => 'string',
+					),
+					'style'       => array(
+						'type' => 'object',
+					),
+				),
+				'supports'    => array(
+					'__experimentalBorder' => array(
+						'color'  => true,
+						'radius' => true,
+						'width'  => true,
+						'style'  => true,
+					),
+				),
+			)
+		);
+		$registry   = WP_Block_Type_Registry::get_instance();
+		$block_type = $registry->get_registered( $block_name );
+		$block_atts = array(
+			'borderColor' => 'red',
+			'style'       => array(
+				'border' => array(
+					'radius' => '10px',
+					'width'  => '1px',
+					'style'  => 'dashed',
+				),
+			),
+		);
+
+		$actual   = wp_apply_border_support( $block_type, $block_atts );
+		$expected = array(
+			'class' => 'has-border-color has-red-border-color',
+			'style' => 'border-radius: 10px; border-style: dashed; border-width: 1px;',
+		);
+
+		$this->assertSame( $expected, $actual );
+		unregister_block_type( $block_name );
+	}
+
+	/**
+	 * @ticket 55505
+	 */
+	function test_border_with_skipped_serialization_block_supports() {
+		$block_name = 'test/border-with-skipped-serialization-block-supports';
+		register_block_type(
+			$block_name,
+			array(
+				'api_version' => 2,
+				'attributes'  => array(
+					'style' => array(
+						'type' => 'object',
+					),
+				),
+				'supports'    => array(
+					'__experimentalBorder' => array(
+						'color'                           => true,
+						'radius'                          => true,
+						'width'                           => true,
+						'style'                           => true,
+						'__experimentalSkipSerialization' => true,
+					),
+				),
+			)
+		);
+		$registry   = WP_Block_Type_Registry::get_instance();
+		$block_type = $registry->get_registered( $block_name );
+		$block_atts = array(
+			'style' => array(
+				'border' => array(
+					'color'  => '#eeeeee',
+					'width'  => '1px',
+					'style'  => 'dotted',
+					'radius' => '10px',
+				),
+			),
+		);
+
+		$actual   = wp_apply_border_support( $block_type, $block_atts );
+		$expected = array();
+
+		$this->assertSame( $expected, $actual );
+		unregister_block_type( $block_name );
+	}
+
+	/**
+	 * @ticket 55505
+	 */
+	function test_radius_with_individual_skipped_serialization_block_supports() {
+		$block_name = 'test/radius-with-individual-skipped-serialization-block-supports';
+		register_block_type(
+			$block_name,
+			array(
+				'api_version' => 2,
+				'attributes'  => array(
+					'style' => array(
+						'type' => 'object',
+					),
+				),
+				'supports'    => array(
+					'__experimentalBorder' => array(
+						'color'                           => true,
+						'radius'                          => true,
+						'width'                           => true,
+						'style'                           => true,
+						'__experimentalSkipSerialization' => array( 'radius', 'color' ),
+					),
+				),
+			)
+		);
+		$registry   = WP_Block_Type_Registry::get_instance();
+		$block_type = $registry->get_registered( $block_name );
+		$block_atts = array(
+			'style' => array(
+				'border' => array(
+					'color'  => '#eeeeee',
+					'width'  => '1px',
+					'style'  => 'dotted',
+					'radius' => '10px',
+				),
+			),
+		);
+
+		$actual   = wp_apply_border_support( $block_type, $block_atts );
+		$expected = array(
+			'style' => 'border-style: dotted; border-width: 1px;',
+		);
+
+		$this->assertSame( $expected, $actual );
+		unregister_block_type( $block_name );
+	}
+}

--- a/tests/phpunit/tests/block-supports/colors.php
+++ b/tests/phpunit/tests/block-supports/colors.php
@@ -44,4 +44,90 @@ class Tests_Block_Supports_Colors extends WP_UnitTestCase {
 		$this->assertSame( $expected, $actual );
 		unregister_block_type( 'test/color-slug-with-numbers' );
 	}
+
+	/**
+	 * @ticket 55505
+	 */
+	function test_color_with_skipped_serialization_block_supports() {
+		$block_name = 'test/color-with-skipped-serialization-block-supports';
+		register_block_type(
+			$block_name,
+			array(
+				'api_version' => 2,
+				'attributes'  => array(
+					'style' => array(
+						'type' => 'object',
+					),
+				),
+				'supports'    => array(
+					'color' => array(
+						'text'                            => true,
+						'gradients'                       => true,
+						'__experimentalSkipSerialization' => true,
+					),
+				),
+			)
+		);
+
+		$registry   = WP_Block_Type_Registry::get_instance();
+		$block_type = $registry->get_registered( $block_name );
+		$block_atts = array(
+			'style' => array(
+				'color' => array(
+					'text'     => '#d92828',
+					'gradient' => 'linear-gradient(135deg,rgb(6,147,227) 0%,rgb(223,13,13) 46%,rgb(155,81,224) 100%)',
+				),
+			),
+		);
+
+		$actual   = wp_apply_colors_support( $block_type, $block_atts );
+		$expected = array();
+
+		$this->assertSame( $expected, $actual );
+		unregister_block_type( $block_name );
+	}
+
+	/**
+	 * @ticket 55505
+	 */
+	function test_gradient_with_individual_skipped_serialization_block_supports() {
+		$block_name = 'test/gradient-with-individual-skipped-serialization-block-support';
+		register_block_type(
+			$block_name,
+			array(
+				'api_version' => 2,
+				'attributes'  => array(
+					'style' => array(
+						'type' => 'object',
+					),
+				),
+				'supports'    => array(
+					'color' => array(
+						'text'                            => true,
+						'gradients'                       => true,
+						'__experimentalSkipSerialization' => array( 'gradients' ),
+					),
+				),
+			)
+		);
+
+		$registry   = WP_Block_Type_Registry::get_instance();
+		$block_type = $registry->get_registered( $block_name );
+		$block_atts = array(
+			'style' => array(
+				'color' => array(
+					'text' => '#d92828',
+				),
+			),
+		);
+
+		$actual   = wp_apply_colors_support( $block_type, $block_atts );
+		$expected = array(
+			'class' => 'has-text-color',
+			'style' => 'color: #d92828;',
+		);
+
+		$this->assertSame( $expected, $actual );
+		unregister_block_type( $block_name );
+	}
 }

--- a/tests/phpunit/tests/block-supports/spacing.php
+++ b/tests/phpunit/tests/block-supports/spacing.php
@@ -1,0 +1,153 @@
+<?php
+/**
+ * @group block-supports
+ */
+class Test_Block_Supports_Spacing extends WP_UnitTestCase {
+
+	/**
+	 * @ticket 55505
+	 */
+	function test_spacing_style_is_applied() {
+		$block_name = 'test/spacing-style-is-applied';
+		register_block_type(
+			$block_name,
+			array(
+				'api_version' => 2,
+				'attributes'  => array(
+					'style' => array(
+						'type' => 'object',
+					),
+				),
+				'supports'    => array(
+					'spacing' => array(
+						'margin'   => true,
+						'padding'  => true,
+						'blockGap' => true,
+					),
+				),
+			)
+		);
+		$registry   = WP_Block_Type_Registry::get_instance();
+		$block_type = $registry->get_registered( $block_name );
+		$block_atts = array(
+			'style' => array(
+				'spacing' => array(
+					'margin'   => array(
+						'top'    => '1px',
+						'right'  => '2px',
+						'bottom' => '3px',
+						'left'   => '4px',
+					),
+					'padding'  => '111px',
+					'blockGap' => '2em',
+				),
+			),
+		);
+
+		$actual   = wp_apply_spacing_support( $block_type, $block_atts );
+		$expected = array(
+			'style' => 'padding: 111px; margin-top: 1px; margin-right: 2px; margin-bottom: 3px; margin-left: 4px;',
+		);
+
+		$this->assertSame( $expected, $actual );
+		unregister_block_type( $block_name );
+	}
+
+	/**
+	 * @ticket 55505
+	 */
+	function test_spacing_with_skipped_serialization_block_supports() {
+		$block_name = 'test/spacing-with-skipped-serialization-block-supports';
+		register_block_type(
+			$block_name,
+			array(
+				'api_version' => 2,
+				'attributes'  => array(
+					'style' => array(
+						'type' => 'object',
+					),
+				),
+				'supports'    => array(
+					'spacing' => array(
+						'margin'                          => true,
+						'padding'                         => true,
+						'blockGap'                        => true,
+						'__experimentalSkipSerialization' => true,
+					),
+				),
+			)
+		);
+		$registry   = WP_Block_Type_Registry::get_instance();
+		$block_type = $registry->get_registered( $block_name );
+		$block_atts = array(
+			'style' => array(
+				'spacing' => array(
+					'margin'   => array(
+						'top'    => '1px',
+						'right'  => '2px',
+						'bottom' => '3px',
+						'left'   => '4px',
+					),
+					'padding'  => '111px',
+					'blockGap' => '2em',
+				),
+			),
+		);
+
+		$actual   = wp_apply_spacing_support( $block_type, $block_atts );
+		$expected = array();
+
+		$this->assertSame( $expected, $actual );
+		unregister_block_type( $block_name );
+	}
+
+	/**
+	 * @ticket 55505
+	 */
+	function test_margin_with_individual_skipped_serialization_block_supports() {
+		$block_name = 'test/margin-with-individual-skipped-serialization-block-supports';
+		register_block_type(
+			$block_name,
+			array(
+				'api_version' => 2,
+				'attributes'  => array(
+					'style' => array(
+						'type' => 'object',
+					),
+				),
+				'supports'    => array(
+					'spacing' => array(
+						'margin'                          => true,
+						'padding'                         => true,
+						'blockGap'                        => true,
+						'__experimentalSkipSerialization' => array( 'margin' ),
+					),
+				),
+			)
+		);
+		$registry   = WP_Block_Type_Registry::get_instance();
+		$block_type = $registry->get_registered( $block_name );
+		$block_atts = array(
+			'style' => array(
+				'spacing' => array(
+					'padding'  => array(
+						'top'    => '1px',
+						'right'  => '2px',
+						'bottom' => '3px',
+						'left'   => '4px',
+					),
+					'margin'   => '111px',
+					'blockGap' => '2em',
+				),
+			),
+		);
+
+		$actual   = wp_apply_spacing_support( $block_type, $block_atts );
+		$expected = array(
+			'style' => 'padding-top: 1px; padding-right: 2px; padding-bottom: 3px; padding-left: 4px;',
+		);
+
+		$this->assertSame( $expected, $actual );
+		unregister_block_type( $block_name );
+	}
+}

--- a/tests/phpunit/tests/block-supports/typography.php
+++ b/tests/phpunit/tests/block-supports/typography.php
@@ -62,6 +62,86 @@ class Tests_Block_Supports_Typography extends WP_UnitTestCase {
 		unregister_block_type( $block_name );
 	}
 
+	/**
+	 * @ticket 55505
+	 */
+	function test_typography_with_skipped_serialization_block_supports() {
+		$block_name = 'test/typography-with-skipped-serialization-block-supports';
+		register_block_type(
+			$block_name,
+			array(
+				'api_version' => 2,
+				'attributes'  => array(
+					'style' => array(
+						'type' => 'object',
+					),
+				),
+				'supports'    => array(
+					'typography' => array(
+						'fontSize'                        => true,
+						'lineHeight'                      => true,
+						'__experimentalFontFamily'        => true,
+						'__experimentalLetterSpacing'     => true,
+						'__experimentalSkipSerialization' => true,
+					),
+				),
+			)
+		);
+		$registry   = WP_Block_Type_Registry::get_instance();
+		$block_type = $registry->get_registered( $block_name );
+		$block_atts = array(
+			'style' => array(
+				'typography' => array(
+					'fontSize'      => 'serif',
+					'lineHeight'    => 'serif',
+					'fontFamily'    => '22px',
+					'letterSpacing' => '22px',
+				),
+			),
+		);
+
+		$actual   = wp_apply_typography_support( $block_type, $block_atts );
+		$expected = array();
+
+		$this->assertSame( $expected, $actual );
+		unregister_block_type( $block_name );
+	}
+
+	/**
+	 * @ticket 55505
+	 */
+	function test_letter_spacing_with_individual_skipped_serialization_block_supports() {
+		$block_name = 'test/letter-spacing-with-individua-skipped-serialization-block-supports';
+		register_block_type(
+			$block_name,
+			array(
+				'api_version' => 2,
+				'attributes'  => array(
+					'style' => array(
+						'type' => 'object',
+					),
+				),
+				'supports'    => array(
+					'typography' => array(
+						'__experimentalLetterSpacing'     => true,
+						'__experimentalSkipSerialization' => array(
+							'letterSpacing',
+						),
+					),
+				),
+			)
+		);
+		$registry   = WP_Block_Type_Registry::get_instance();
+		$block_type = $registry->get_registered( $block_name );
+		$block_atts = array( 'style' => array( 'typography' => array( 'letterSpacing' => '22px' ) ) );
+
+		$actual   = wp_apply_typography_support( $block_type, $block_atts );
+		$expected = array();
+
+		$this->assertSame( $expected, $actual );
+		unregister_block_type( $block_name );
+	}
+
 	function test_font_family_with_legacy_inline_styles_using_a_css_var() {
 		$block_name = 'test/font-family-with-inline-styles-using-css-var';
 		register_block_type(

--- a/tests/phpunit/tests/query/commentFeed.php
+++ b/tests/phpunit/tests/query/commentFeed.php
@@ -1,0 +1,112 @@
+<?php
+
+/**
+ * @group query
+ * @group comments
+ * @group feeds
+ */
+class Tests_Query_CommentFeed extends WP_UnitTestCase {
+	public static $post_type   = 'post';
+	protected static $post_ids = array();
+
+	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
+		self::$post_ids = $factory->post->create_many(
+			3,
+			array(
+				'post_type'   => self::$post_type,
+				'post_status' => 'publish',
+			)
+		);
+		foreach ( self::$post_ids as $post_id ) {
+			$factory->comment->create_post_comments( $post_id, 5 );
+		}
+
+		update_option( 'posts_per_rss', 100 );
+	}
+
+	/**
+	 * @ticket 36904
+	 */
+	public function test_archive_comment_feed() {
+		global $wpdb;
+		add_filter( 'split_the_query', '__return_false' );
+		$q1   = new WP_Query();
+		$args = array(
+			'withcomments'           => 1,
+			'feed'                   => 'comments-rss',
+			'post_type'              => self::$post_type,
+			'update_post_meta_cache' => false,
+			'update_post_term_cache' => false,
+			'ignore_sticky_posts'    => false,
+			'no_found_rows'          => true,
+		);
+		$q1->query( $args );
+		$num_queries = $wpdb->num_queries;
+		$q2          = new WP_Query();
+		$q2->query( $args );
+		$this->assertTrue( $q2->is_comment_feed() );
+		$this->assertFalse( $q2->is_singular() );
+		$this->assertSame( $num_queries + 1, $wpdb->num_queries );
+	}
+
+	/**
+	 * @ticket 36904
+	 */
+	public function test_archive_comment_feed_invalid_cache() {
+		$q1   = new WP_Query();
+		$args = array(
+			'withcomments'           => 1,
+			'feed'                   => 'comments-rss',
+			'post_type'              => self::$post_type,
+			'update_post_meta_cache' => false,
+			'update_post_term_cache' => false,
+			'ignore_sticky_posts'    => false,
+		);
+		$q1->query( $args );
+		$comment_count = $q1->comment_count;
+		$this->assertSame( 15, $comment_count );
+
+		$post = self::factory()->post->create_and_get(
+			array(
+				'post_type'   => self::$post_type,
+				'post_status' => 'publish',
+			)
+		);
+		self::factory()->comment->create_post_comments( $post->ID, 5 );
+		$q2 = new WP_Query();
+		$q2->query( $args );
+		$this->assertTrue( $q2->is_comment_feed() );
+		$this->assertFalse( $q2->is_singular() );
+
+		$comment_count = $q2->comment_count;
+		$this->assertSame( 20, $comment_count );
+	}
+
+	/**
+	 * @ticket 36904
+	 */
+	public function test_single_comment_feed() {
+		global $wpdb;
+		$post = get_post( self::$post_ids[0] );
+
+		$q1   = new WP_Query();
+		$args = array(
+			'withcomments'           => 1,
+			'feed'                   => 'comments-rss',
+			'post_type'              => $post->post_type,
+			'name'                   => $post->post_name,
+			'update_post_meta_cache' => false,
+			'update_post_term_cache' => false,
+			'ignore_sticky_posts'    => false,
+		);
+
+		$q1->query( $args );
+		$num_queries = $wpdb->num_queries;
+		$q2          = new WP_Query();
+		$q2->query( $args );
+
+		$this->assertTrue( $q2->is_comment_feed() );
+		$this->assertTrue( $q2->is_singular() );
+		$this->assertSame( $num_queries + 1, $wpdb->num_queries );
+	}
+}

--- a/tests/phpunit/tests/rest-api/rest-global-styles-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-global-styles-controller.php
@@ -117,6 +117,11 @@ class WP_REST_Global_Styles_Controller_Test extends WP_Test_REST_Controller_Test
 			$routes['/wp/v2/global-styles/themes/(?P<stylesheet>[^\/:<>\*\?"\|]+(?:\/[^\/:<>\*\?"\|]+)?)'],
 			'Theme global styles route does not have exactly one element'
 		);
+		$this->assertArrayHasKey(
+			'/wp/v2/global-styles/themes/(?P<stylesheet>[\/\s%\w\.\(\)\[\]\@_\-]+)/variations',
+			$routes,
+			'Theme global styles variations route does not exist'
+		);
 	}
 
 	public function test_context_param() {
@@ -454,5 +459,43 @@ class WP_REST_Global_Styles_Controller_Test extends WP_Test_REST_Controller_Test
 		$this->assertArrayHasKey( 'styles', $properties, 'Schema properties array does not have "styles" key' );
 		$this->assertArrayHasKey( 'settings', $properties, 'Schema properties array does not have "settings" key' );
 		$this->assertArrayHasKey( 'title', $properties, 'Schema properties array does not have "title" key' );
+	}
+
+
+	public function test_get_theme_items() {
+		wp_set_current_user( self::$admin_id );
+		switch_theme( 'block-theme' );
+		$request  = new WP_REST_Request( 'GET', '/wp/v2/global-styles/themes/block-theme/variations' );
+		$response = rest_get_server()->dispatch( $request );
+		$data     = $response->get_data();
+		$expected = array(
+			array(
+				'version'  => 2,
+				'settings' => array(
+					'color' => array(
+						'palette' => array(
+							'theme' => array(
+								array(
+									'slug'  => 'foreground',
+									'color' => '#3F67C6',
+									'name'  => 'Foreground',
+								),
+							),
+						),
+					),
+				),
+				'styles'   => array(
+					'blocks' => array(
+						'core/post-title' => array(
+							'typography' => array(
+								'fontWeight' => '700',
+							),
+						),
+					),
+				),
+				'title'    => 'variation',
+			),
+		);
+		$this->assertSameSetsWithIndex( $data, $expected );
 	}
 }

--- a/tests/phpunit/tests/rest-api/rest-schema-setup.php
+++ b/tests/phpunit/tests/rest-api/rest-schema-setup.php
@@ -136,6 +136,7 @@ class WP_Test_REST_Schema_Initialization extends WP_Test_REST_TestCase {
 			'/wp/v2/comments',
 			'/wp/v2/comments/(?P<id>[\\d]+)',
 			'/wp/v2/global-styles/(?P<id>[\/\w-]+)',
+			'/wp/v2/global-styles/themes/(?P<stylesheet>[\/\s%\w\.\(\)\[\]\@_\-]+)/variations',
 			'/wp/v2/global-styles/themes/(?P<stylesheet>[^\/:<>\*\?"\|]+(?:\/[^\/:<>\*\?"\|]+)?)',
 			'/wp/v2/search',
 			'/wp/v2/block-renderer/(?P<name>[a-z0-9-]+/[a-z0-9-]+)',

--- a/tests/qunit/fixtures/wp-api-generated.js
+++ b/tests/qunit/fixtures/wp-api-generated.js
@@ -9424,6 +9424,26 @@ mockedApiResponse.Schema = {
                 }
             ]
         },
+        "/wp/v2/global-styles/themes/(?P<stylesheet>[\\/\\s%\\w\\.\\(\\)\\[\\]\\@_\\-]+)/variations": {
+            "namespace": "wp/v2",
+            "methods": [
+                "GET"
+            ],
+            "endpoints": [
+                {
+                    "methods": [
+                        "GET"
+                    ],
+                    "args": {
+                        "stylesheet": {
+                            "description": "The theme identifier",
+                            "type": "string",
+                            "required": false
+                        }
+                    }
+                }
+            ]
+        },
         "/wp/v2/global-styles/themes/(?P<stylesheet>[^\\/:<>\\*\\?\"\\|]+(?:\\/[^\\/:<>\\*\\?\"\\|]+)?)": {
             "namespace": "wp/v2",
             "methods": [


### PR DESCRIPTION
Proposed changes to `wp-admin/options-permalink.php` and `/wp-admin/css/forms.css`:
- Move `legend` inside `fieldset`
- Add `presentation` role to the table
- Move `structure-selection` class to the `fieldset`
- Remove unnecessary `span` tag in `legend`
- Pull inputs (and other elements) out of the labels
- Rename paragraph class to avoid low color contrast
- Remove new `!important` instance
- Add missing label for "Custom Permalink Structure Tags"
- Wrap custom option's URL and input in `span` tag for RTL support

The rest of these changes are updating other files to trunk.